### PR TITLE
Remove trailing whitespace from left context

### DIFF
--- a/code4me-server/src/api.py
+++ b/code4me-server/src/api.py
@@ -40,7 +40,8 @@ def autocomplete():
     if res is not None:
         return res
 
-    left_context = values["leftContext"]
+    # remove trailing whitespace from left context - tokens usually include a leading space, so this should improve accuracy
+    left_context = (values["leftContext"] or "").rstrip()
     right_context = values["rightContext"]
     store_context = values.get("storeContext", False) is True
 


### PR DESCRIPTION
Usually tokens include a leading whitespace (represented as Ġ -> "Hello world" becomes [Hello, Ġworld]). Hence, the models should be better when trailing whitespaces are not in the input