### PR TITLE
Separate r-stripping prefix from saving

### DIFF
--- a/code4me-server/src/api.py
+++ b/code4me-server/src/api.py
@@ -42,7 +42,8 @@ def autocomplete():
         return res
 
     # remove trailing whitespace from left context - tokens usually include a leading space, so this should improve accuracy
-    left_context = (values["leftContext"] or "").rstrip()
+    left_context = values["leftContext"] or ""
+    stripped_left_context = left_context.rstrip()
     right_context = values["rightContext"]
     store_context = values.get("storeContext", False) is True
 
@@ -52,7 +53,7 @@ def autocomplete():
 
     def predict_model(model: Model) -> List[str]:
         try:
-            return model.value[1](left_context, right_context)
+            return model.value[1](stripped_left_context, right_context)
         except torch.cuda.OutOfMemoryError:
             exit(1)
 


### PR DESCRIPTION
Currently, the prefix (left context) is modified before saving. This makes it difficult to analyse the contextual prefix data, as it is irreversibly modified. I have created a new variable for the stripped prefix which is then submitted to the model. 