### PR TITLE
Aral's User Study

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ build
 venv
 __pycache__
 users*.json
+data_aral
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 users*.json
 data_aral
 
+models

--- a/code4me-server/src/app.py
+++ b/code4me-server/src/app.py
@@ -1,15 +1,18 @@
-from pathlib import Path
+import markdown, os
 
-import markdown
+from pathlib import Path
 from flask import Flask, jsonify, render_template
-from api import v1
+from api import v1, v2
 from limiter import limiter
 
 app = Flask(__name__, static_folder="static", template_folder="templates")
 limiter.init_app(app)
 app.register_blueprint(v1, url_prefix='/api/v1')
+app.register_blueprint(v2, url_prefix='/api/v2')
 
-index_md = markdown.markdown(Path("markdowns/index.md").read_text())
+# TODO: (revert) remove if and beyond
+markdown_path = 'markdowns/index.md' if Path('markdowns/index.md').exists() else Path(os.getcwd(), '..', 'markdowns/index.md')
+index_md = markdown.markdown(Path(markdown_path).read_text())
 
 
 @app.errorhandler(429)

--- a/code4me-server/src/app.py
+++ b/code4me-server/src/app.py
@@ -10,8 +10,7 @@ limiter.init_app(app)
 app.register_blueprint(v1, url_prefix='/api/v1')
 app.register_blueprint(v2, url_prefix='/api/v2')
 
-# TODO: (revert) remove if and beyond
-markdown_path = 'markdowns/index.md' if Path('markdowns/index.md').exists() else Path(os.getcwd(), '..', 'markdowns/index.md')
+markdown_path = 'markdowns/index.md' 
 index_md = markdown.markdown(Path(markdown_path).read_text())
 
 

--- a/code4me-server/src/model.py
+++ b/code4me-server/src/model.py
@@ -2,25 +2,27 @@ import os
 from enum import Enum
 from typing import Callable
 
-# TODO: (revert) remove up to `else:`
-if os.getenv("CODE4ME_TEST", "false") == "true":
-    print('''
-        \033[1m WARNING: RUNNING IN TEST MODE \033[0m
-          ''')
-    # if the env variable TEST_MODE is set to True, then remap model.generate to lambda: 'model_name'
+# NOTE: Convenient for testing, use preset generate functions
+# if os.getenv("CODE4ME_TEST", "false") == "true":
+#     print('''
+#         \033[1m WARNING: RUNNING IN TEST MODE \033[0m
+#           ''')
+#     # if the env variable TEST_MODE is set to True, then remap model.generate to lambda: 'model_name'
 
-    incoder = type("InCoder", (object,), {})
-    unixcoder_wrapper = type("UniXCoder", (object,), {})
-    codegpt = type("CodeGPT", (object,), {})
+#     incoder = type("InCoder", (object,), {})
+#     unixcoder_wrapper = type("UniXCoder", (object,), {})
+#     import codegpt 
+#     # codegpt = type("CodeGPT", (object,), {})
 
-    incoder.generate = lambda left, right: ['predict_incoder']
-    unixcoder_wrapper.generate = lambda left, right: [' predict_unixcoder']
-    codegpt.codegpt_predict = lambda left, right: [' (predict_codegpt']
-else: 
-    # ooh yeah, import statements in an else stmt; i see new things every day 
-    import incoder
-    import unixcoder_wrapper
-    import codegpt
+#     incoder.generate = lambda left, right: ['predict_incoder']
+#     unixcoder_wrapper.generate = lambda left, right: [' predict_unixcoder']
+    
+#     # codegpt.codegpt_predict = lambda left, right: [' (predict_codegpt']
+# else: 
+#     # ooh yeah, import statements in an else stmt; i see new things every day 
+import incoder
+import unixcoder_wrapper
+import codegpt
 
 class Model(Enum):
     InCoder = (0, incoder.generate)

--- a/code4me-server/src/model.py
+++ b/code4me-server/src/model.py
@@ -1,7 +1,25 @@
+import os 
 from enum import Enum
-import incoder
-import unixcoder_wrapper
-import codegpt
+
+# TODO: (revert) remove up to `else:`
+if os.getenv("CODE4ME_TEST", "false") == "true":
+    print('''
+        \033[1m WARNING: RUNNING IN TEST MODE \033[0m
+          ''')
+    # if the env variable TEST_MODE is set to True, then remap model.generate to lambda: 'model_name'
+
+    incoder = type("InCoder", (object,), {})
+    unixcoder_wrapper = type("UniXCoder", (object,), {})
+    codegpt = type("CodeGPT", (object,), {})
+
+    incoder.generate = lambda left, right: "incoder"
+    unixcoder_wrapper.generate = lambda left, right: "unixcoder"
+    codegpt.codegpt_predict = lambda left, right: "codegpt"
+else: 
+    # ooh yeah, import statements in an else stmt; i see new things every day 
+    import incoder
+    import unixcoder_wrapper
+    import codegpt
 
 class Model(Enum):
     InCoder = (0, incoder.generate)

--- a/code4me-server/src/model.py
+++ b/code4me-server/src/model.py
@@ -15,3 +15,11 @@ class Model(Enum):
                 if item.value[0] == value:
                     return item
         return super()._missing_(value)
+
+
+class Models(Enum):
+    ''' New model enum because I don't want to keep track of indices in my user study - Aral '''
+
+    InCoder     = incoder.generate 
+    UniXCoder   = unixcoder_wrapper.generate
+    CodeGPT     = codegpt.codegpt_predict

--- a/code4me-server/src/model.py
+++ b/code4me-server/src/model.py
@@ -14,8 +14,8 @@ if os.getenv("CODE4ME_TEST", "false") == "true":
     codegpt = type("CodeGPT", (object,), {})
 
     incoder.generate = lambda left, right: ['predict_incoder']
-    unixcoder_wrapper.generate = lambda left, right: ['predict_unixcoder']
-    codegpt.codegpt_predict = lambda left, right: ['predict_codegpt']
+    unixcoder_wrapper.generate = lambda left, right: [' predict_unixcoder']
+    codegpt.codegpt_predict = lambda left, right: [' (predict_codegpt']
 else: 
     # ooh yeah, import statements in an else stmt; i see new things every day 
     import incoder

--- a/code4me-server/src/model.py
+++ b/code4me-server/src/model.py
@@ -1,5 +1,6 @@
 import os 
 from enum import Enum
+from typing import Callable
 
 # TODO: (revert) remove up to `else:`
 if os.getenv("CODE4ME_TEST", "false") == "true":
@@ -12,9 +13,9 @@ if os.getenv("CODE4ME_TEST", "false") == "true":
     unixcoder_wrapper = type("UniXCoder", (object,), {})
     codegpt = type("CodeGPT", (object,), {})
 
-    incoder.generate = lambda left, right: "incoder"
-    unixcoder_wrapper.generate = lambda left, right: "unixcoder"
-    codegpt.codegpt_predict = lambda left, right: "codegpt"
+    incoder.generate = lambda left, right: ['predict_incoder']
+    unixcoder_wrapper.generate = lambda left, right: ['predict_unixcoder']
+    codegpt.codegpt_predict = lambda left, right: ['predict_codegpt']
 else: 
     # ooh yeah, import statements in an else stmt; i see new things every day 
     import incoder
@@ -33,11 +34,3 @@ class Model(Enum):
                 if item.value[0] == value:
                     return item
         return super()._missing_(value)
-
-
-class Models(Enum):
-    ''' New model enum because I don't want to keep track of indices in my user study - Aral '''
-
-    InCoder     = incoder.generate 
-    UniXCoder   = unixcoder_wrapper.generate
-    CodeGPT     = codegpt.codegpt_predict

--- a/code4me-server/src/modeling_jonberta.py
+++ b/code4me-server/src/modeling_jonberta.py
@@ -1,0 +1,994 @@
+from typing import List, Optional, Tuple, Union, Any
+from copy import deepcopy
+import torch, math
+
+from torch import nn, Tensor
+from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss, init
+
+from transformers.models.roberta.modeling_roberta import (
+    RobertaForSequenceClassification,
+    RobertaPreTrainedModel, 
+    RobertaClassificationHead, 
+    RobertaModel, 
+    RobertaEncoder, 
+    RobertaEmbeddings,
+    RobertaPooler,
+    RobertaAttention,
+    RobertaIntermediate,
+    RobertaOutput,
+    RobertaSelfOutput,
+)
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_outputs import SequenceClassifierOutput, BaseModelOutputWithPastAndCrossAttentions
+from transformers.pytorch_utils import apply_chunking_to_forward
+
+''' Encoder model with cross-attention to feature vectors 
+    Based on the RobertaForSequenceClassification model, only modifying
+    the necessary classes for my use-case. '''
+
+def add_features_to_model(model, config): 
+    ''' Modify the weights of the given `nn.Linear` `model_layer` to include `n_features` 
+        more features, and optionally re-initialize that layer's weights. 
+        Used to augment the classification head '''
+    
+    if not config_has(config, [add_head]):
+        return model
+
+    if not config_has(config, [num_telemetry_features]):
+        raise ValueError('You should specify a `num_telemetry_features`')
+    n_features = config_has(config, [num_telemetry_features])
+
+    def rec_getattr(obj, layer):
+
+        # recursive getattr
+        layers = layer.split('.')
+        prev_layer, old_layer = model, model
+        for layer in layers: 
+            prev_layer = old_layer
+            old_layer = getattr(old_layer, layer)
+        return old_layer, prev_layer, layers
+
+    re_init = config_has(config, [reinit_head])
+    if config_has(config, [add_dense, add_proj]):
+        print('expanding both dense and proj')
+        # C x C+m x n_labels, where C is hidden_size, m is n_features
+        old_dense, prev_layer, layers = rec_getattr(model, 'classifier.dense')
+        new_dense = torch.nn.Linear(
+            old_dense.in_features + n_features, 
+            old_dense.out_features + n_features
+        )
+        if not re_init:
+            new_dense.weight.data[:old_dense.out_features, :old_dense.in_features] = old_dense.weight.data
+            new_dense.bias.data[:old_dense.out_features] = old_dense.bias.data
+
+        setattr(prev_layer, layers[-1], new_dense)
+
+        old_proj, prev_layer, layers = rec_getattr(model, 'classifier.out_proj')
+        new_proj = torch.nn.Linear(
+            old_proj.in_features + n_features, 
+            old_proj.out_features
+        )
+        if not re_init:
+            new_proj.weight.data[:old_proj.out_features, :old_proj.in_features] = old_proj.weight.data
+            new_proj.bias.data[:old_proj.out_features] = old_proj.bias.data
+
+        setattr(prev_layer, layers[-1], new_proj)
+        return model
+        
+    elif config_has(config, [add_dense]):
+        layer_name = 'classifier.dense'
+    elif config_has(config, [add_proj]):
+        layer_name = 'classifier.out_proj'
+    else:
+        return model
+    
+    print(f'expanding {layer_name}')
+    old_layer, prev_layer, layers = rec_getattr(model, layer_name)
+    new_layer = torch.nn.Linear(old_layer.in_features + n_features, old_layer.out_features)
+    if not re_init: 
+        new_layer.weight.data[:, :old_layer.in_features] = old_layer.weight.data
+        new_layer.bias.data = old_layer.bias.data
+    old_layer = new_layer
+
+    setattr(prev_layer, layers[-1], new_layer)
+
+def dprint(matrix: Tensor, label: str, dims=None):
+    ''' debug print method '''
+    shape = matrix.shape
+    if dims is not None: 
+        matrix = matrix[dims]
+        es = matrix.shape
+
+    print(f'\n{label}, {shape}, {es if dims is not None else ""} \n{matrix}')
+
+def config_has(config: PretrainedConfig, keys: tuple[str]) -> bool | Any:
+    ''' Check whether config contains a given key, and return True if it is set to True. 
+        The amount of built-ins called indicates that this should be a built-in python function. '''
+    # if all keys are present
+    if all([hasattr(config, key) for key in keys]):
+        # get all values
+        values = [getattr(config, key) for key in keys]
+        # if all values are booleans, simply check if all are True
+        if all([isinstance(value, bool) for value in values]):
+            return all(values)
+        # else, check if all boolean values are True, and return the last value
+        elif all(filter(lambda value: isinstance(value, bool), values)):
+            return values[-1]
+    return False
+
+# all modifications, and their config entries, are listed here 
+num_telemetry_features = 'num_telemetry_features' # int (26)
+
+# NOTE: Classification Head
+add_head = 'add_head' # bool
+add_dense = 'add_dense' # bool
+add_proj = 'add_proj' # bool
+reinit_head = 'reinit_head' # bool
+
+# NOTE: Cross Attention
+add_cross_attn = 'add_cross_attn' # bool
+share_values = 'share_values' # bool
+cross_attn_layers = 'cross_attn_layers' # list[int]
+
+# NOTE: Self Attention
+add_self_attn = 'add_self_attn' # bool
+share_feature_values = 'share_self_attn_values' # bool
+share_feature_keys = 'share_self_attn_keys' # bool
+self_attn_layers = 'self_attn_layers' # list[int]
+
+# NOTE: Feature Embeddings for Self Attention
+add_feature_embeddings = 'add_feature_embeddings' # bool
+feature_hidden_size = 'feature_hidden_size' # int (presumably in [n_feature, hidden_size], scales added param count exponentially)
+feature_dropout_prob = 'feature_dropout_prob'
+add_feature_bias = 'add_feature_bias' # bool
+
+# NOTE: not in use
+cross_attn_v2 = 'cross_attn_v2' # bool
+share_keys = 'share_keys'   # bool
+use_queries = 'use_queries' # bool
+
+# TODO: add proper error handling if any of these are missing 
+
+class Hadamard(nn.Module):
+    '''
+    Oh yeah baby, we have to make our own module for something as simple as element-wise multiplication 
+    Or, at least, I cannot find a suitable equivalent in reasonable time within the PyTorch Library. 
+    Surely someone must've made this already?
+    '''
+    __constants__ = ['in_features', 'out_features']
+    in_features: int
+    out_features: int
+    weight: Tensor
+
+    # Methods based on nn.Linear. However, we do not include bias by default as this 
+    # does not really make sense for an element-wise multiplication.
+    def __init__(self, in_features: int, out_features: int, bias: bool = False,
+                 device=None, dtype=None) -> None:
+        factory_kwargs = {'device': device, 'dtype': dtype}
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        # print(factory_kwargs)
+        self.weight = nn.Parameter(torch.empty((out_features, in_features), **factory_kwargs))
+        if bias:
+            self.bias = nn.Parameter(torch.empty((out_features, in_features), **factory_kwargs))
+        else:
+            self.register_parameter('bias', None)
+        # print(f'before: {self.weight}')
+        self.reset_parameters()
+        # print(f'after: {self.weight}')
+
+    def reset_parameters(self) -> None:
+        # Setting a=sqrt(5) in kaiming_uniform is the same as initializing with
+        # uniform(-1/sqrt(in_features), 1/sqrt(in_features)). For details, see
+        # https://github.com/pytorch/pytorch/issues/57109
+        # import pdb; pdb.set_trace()
+        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is not None:
+            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            init.uniform_(self.bias, -bound, bound)
+
+    def forward(self, input: Tensor) -> Tensor:
+        ''' NEW: Element-wise multiplication + optional bias '''
+        # return F.linear(input, self.weight, self.bias)
+        if self.bias is not None: 
+            return torch.mul(input.unsqueeze(-1), self.weight.t()) + self.bias.t()
+        return torch.mul(input.unsqueeze(-1), self.weight.t()) 
+
+    def extra_repr(self) -> str:
+        return f'in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}'
+
+class JonbertaEmbeddings(nn.Module):
+    ''' embeddings with a spicy kick for scalar feature data 
+        learns a nonlinear function for each item in the embedding of the feature '''
+
+    def __init__(self, config):
+        super().__init__()
+
+        if not hasattr(config, feature_hidden_size):
+            raise ValueError('You should specify a `feature_hidden_size`, or at least set it to `hidden_size`')
+        
+        self.feature_embeddings = Hadamard(
+            config.get(num_telemetry_features), config.get(feature_hidden_size), 
+            bias = config.get(add_feature_bias)) 
+        # self.softmax = nn.functional.softmax 
+        self.nonlinear = nn.functional.gelu
+        # TODO: actually read layernorm documentation
+        self.layer_norm = nn.LayerNorm(config.get(feature_hidden_size)) 
+        self.dropout = nn.Dropout(config.get(feature_dropout_prob))
+
+        # dprint(self.feature_embeddings.weight, 'emb weights', 0)
+        # dprint(self.feature_embeddings.bias, 'emb bias', 0)
+
+    def forward(self, features=None): # , token_type_ids=None, position_ids=None, inputs_embeds=None, past_key_values_length=0
+        
+        # dprint(self.feature_embeddings.weight, 'emb weights')
+        # dprint(self.feature_embeddings.bias, 'emb bias')
+        # dprint(features, 'features', 0)
+        embeddings = self.feature_embeddings(features)
+        # dprint(embeddings, 'embedded', 0)
+        # TODO: bias term may not be necessary in embeddings, as we normalise after
+        embeddings = self.layer_norm(embeddings)
+        # dprint(embeddings, 'normed', 0)
+        # TODO: try out layer_norm after gelu, as gelu does not map everything negative to 0 and thus biases the layer norm less 
+        embeddings = self.nonlinear(embeddings)
+        # dprint(embeddings, 'nonlinear', 0)
+
+        embeddings = self.dropout(embeddings)
+        # dprint(embeddings, 'dropout', 0)
+
+        return embeddings
+
+class JonbertaEncoder(RobertaEncoder):
+    ''' Custom encoder so we can specify our custom JonbertaLayer '''
+    def __init__(self, config):
+        super(RobertaEncoder, self).__init__() # Changed super() -> super(RobertaEncoder, self)
+        self.config = config
+        
+        # would've loved to put this in the JonbertaModel along WE, but im not copying over that entire forward() function
+        if config.get(add_feature_embeddings):
+            self.feature_embeddings = JonbertaEmbeddings(config)
+
+        self.layer = nn.ModuleList([JonbertaLayer(config, layer_idx=i) for i in range(config.num_hidden_layers)]) # Changed RobertaLayer -> JonbertaLayer
+        self.gradient_checkpointing = False
+
+        # NOTE: I hate this 'design pattern' but I am out of alternatives, Python...
+        if config.get(add_cross_attn, share_values):
+            self.shared_value = Hadamard(config.num_telemetry_features, config.hidden_size) # without bias
+        elif config.get(add_self_attn):
+            if config.get(share_feature_values):
+                self.shared_value = nn.Linear(config.num_telemetry_features, config.hidden_size)
+            if config.get(share_feature_keys):
+                self.shared_keys = nn.Linear(config.num_telemetry_features, config.hidden_size)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        encoder_hidden_states: Optional[torch.FloatTensor] = None,
+        encoder_attention_mask: Optional[torch.FloatTensor] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = False,
+        output_hidden_states: Optional[bool] = False,
+        return_dict: Optional[bool] = True,
+    ) -> Union[Tuple[torch.Tensor], BaseModelOutputWithPastAndCrossAttentions]:
+
+        if self.config.get(add_feature_embeddings):
+            encoder_hidden_states = self.feature_embeddings(encoder_hidden_states)
+
+        if self.config.get(add_cross_attn, share_values):
+            encoder_hidden_states = self.shared_value(encoder_hidden_states)
+            encoder_hidden_states = encoder_hidden_states.unsqueeze(1) # for handling the single T dimension 
+        
+        if self.config.get(add_self_attn, share_feature_values):
+            encoder_values = self.shared_value(encoder_hidden_states).unsqueeze(1)
+            raise NotImplementedError('Shared values (self-attn) not implemented yet')
+
+        if self.config.get(add_self_attn, share_feature_keys):
+            encoder_keys = self.shared_keys(encoder_hidden_states).unsqueeze(1)
+            raise NotImplementedError('Shared keys (self-attn) not implemented yet')
+
+        
+        return super().forward(
+            hidden_states,
+            attention_mask=attention_mask,
+            head_mask=head_mask,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+class JonbertaLayer(nn.Module):
+    ''' Layer with following potential additions: 
+        - modified self-attention with KV from features (config.add_self_attn)
+        - modified cross-attention with KV from features (config.add_cross_attn)
+    '''
+
+    def __init__(self, config, layer_idx=None):
+        super().__init__()
+        self.chunk_size_feed_forward = config.chunk_size_feed_forward
+        self.seq_len_dim = 1
+        self.layer_idx = layer_idx
+        self.config = config
+
+        self.custom_self_attn = config.get(add_self_attn) and layer_idx in config.get(self_attn_layers)
+        self.custom_cross_attn = config.get(add_cross_attn) and layer_idx in config.get(cross_attn_layers)
+
+        if self.custom_self_attn and self.custom_cross_attn:
+            raise ValueError('Should not specify both custom self- and cross-attention.')
+
+        if self.custom_self_attn:
+            print(f'Adding custom self-attention to layer {layer_idx}')
+            self.attention = JonbertaSelfAttention(config) 
+
+        elif self.custom_cross_attn:
+            print(f'Adding custom cross-attention to layer {layer_idx}')
+            self.attention = JonbertaCrossAttention(config, layer_idx=layer_idx)
+
+        else:
+            self.attention = RobertaAttention(config) # original RobertaSelfAttention
+       
+        self.intermediate = RobertaIntermediate(config)
+        self.output = RobertaOutput(config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        encoder_hidden_states: Optional[torch.FloatTensor] = None,
+        encoder_attention_mask: Optional[torch.FloatTensor] = None,
+        past_key_value: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+        output_attentions: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor]:
+        # decoder uni-directional self-attention cached key/values tuple is at positions 1,2
+        self_attn_past_key_value = past_key_value[:2] if past_key_value is not None else None
+        self_attention_outputs = self.attention(
+            hidden_states,
+            attention_mask,
+            head_mask,
+            output_attentions=output_attentions,
+            past_key_value=self_attn_past_key_value,
+            # we only want to pass encoder_hidden_states (features) to our own SelfAttention module, 
+            # as otherwise the RobertaAttention module will act like cross-attention and ignore the token embs
+            encoder_hidden_states=encoder_hidden_states if self.custom_self_attn else None,
+            encoder_attention_mask=encoder_attention_mask if self.custom_self_attn else None,
+        )
+        attention_output = self_attention_outputs[0]
+
+        # if decoder, the last output is tuple of self-attn cache
+        if self.config.get(add_cross_attn):
+            outputs = self_attention_outputs[1:-1]
+            present_key_value = (self_attention_outputs[-1],) # NOTE: What's this for? 
+        else:
+            outputs = self_attention_outputs[1:]  # add self attentions if we output attention weights
+
+        cross_attn_present_key_value = None
+        
+        if encoder_hidden_states is not None:
+
+            # and self.add_cross_attention: # NOTE: Changed from `and self.is_decoder`
+            # if not hasattr(self, "crossattention"):
+            #     raise ValueError(
+            #         f"If `encoder_hidden_states` are passed, {self} has to be instantiated with cross-attention layers"
+            #         " by setting `config.add_cross_attention=True`"
+            #     )
+            if self.config.get(add_cross_attn):
+                
+                # cross_attn cached key/values tuple is at positions 3,4 of past_key_value tuple
+                cross_attn_past_key_value = past_key_value[-2:] if past_key_value is not None else None
+                cross_attention_outputs = self.crossattention(
+                    attention_output,
+                    attention_mask,
+                    head_mask,
+                    encoder_hidden_states,
+                    encoder_attention_mask,
+                    cross_attn_past_key_value,
+                    output_attentions,
+                )
+                attention_output = cross_attention_outputs[0]
+                outputs = outputs + cross_attention_outputs[1:-1]  # add cross attentions if we output attention weights
+
+                # add cross-attn cache to positions 3,4 of present_key_value tuple
+                # cross_attn_present_key_value = cross_attention_outputs[-1]
+                # present_key_value = present_key_value + cross_attn_present_key_value
+
+            else:  # no cross-attention, just append the cross_attn_past_key_value for potential future layers
+                # present_key_value = present_key_value + cross_attn_past_key_value
+                pass 
+
+        layer_output = apply_chunking_to_forward(
+            self.feed_forward_chunk, self.chunk_size_feed_forward, self.seq_len_dim, attention_output
+        )
+        outputs = (layer_output,) + outputs
+
+        # if decoder, return the attn key/values as the last output
+        if self.config.get(add_cross_attn): # NOTE: changed from `self.is_decoder:`
+            outputs = outputs + (present_key_value,)
+
+        return outputs
+
+    def feed_forward_chunk(self, attention_output):
+        intermediate_output = self.intermediate(attention_output)
+        layer_output = self.output(intermediate_output, attention_output)
+        return layer_output
+
+class JonbertaSelfAttention(nn.Module):
+    def __init__(self, config, position_embedding_type=None):
+        super().__init__()
+        self.self = SelfAttention(config, position_embedding_type=position_embedding_type)
+        self.output = RobertaSelfOutput(config)
+        self.pruned_heads = set()
+
+    def prune_heads(self, heads):
+        raise NotImplementedError('Pruning not (yet) implemented for Jonberta model')
+        # if len(heads) == 0:
+        #     return
+        # heads, index = find_pruneable_heads_and_indices(
+        #     heads, self.self.num_attention_heads, self.self.attention_head_size, self.pruned_heads
+        # )
+
+        # # Prune linear layers
+        # self.self.query = prune_linear_layer(self.self.query, index)
+        # self.self.key = prune_linear_layer(self.self.key, index)
+        # self.self.value = prune_linear_layer(self.self.value, index)
+        # self.output.dense = prune_linear_layer(self.output.dense, index, dim=1)
+
+        # # Update hyper params and store pruned heads
+        # self.self.num_attention_heads = self.self.num_attention_heads - len(heads)
+        # self.self.all_head_size = self.self.attention_head_size * self.self.num_attention_heads
+        # self.pruned_heads = self.pruned_heads.union(heads)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        encoder_hidden_states: Optional[torch.FloatTensor] = None,
+        encoder_attention_mask: Optional[torch.FloatTensor] = None,
+        past_key_value: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+        output_attentions: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor]:
+        self_outputs = self.self(
+            hidden_states,
+            attention_mask,
+            head_mask,
+            encoder_hidden_states,
+            encoder_attention_mask,
+            past_key_value,
+            output_attentions,
+        )
+        attention_output = self.output(self_outputs[0], hidden_states)
+        outputs = (attention_output,) + self_outputs[1:]  # add attentions if we output them
+        return outputs
+
+class SelfAttention(nn.Module):
+    def __init__(self, config, position_embedding_type=None):
+        super().__init__()
+        if config.hidden_size % config.num_attention_heads != 0 and not hasattr(config, "embedding_size"):
+            raise ValueError(
+                f"The hidden size ({config.hidden_size}) is not a multiple of the number of attention "
+                f"heads ({config.num_attention_heads})"
+            )
+
+        self.num_attention_heads = config.num_attention_heads
+        self.attention_head_size = int(config.hidden_size / config.num_attention_heads)
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+
+        self.query = nn.Linear(config.hidden_size, self.all_head_size)
+        self.key = nn.Linear(config.hidden_size, self.all_head_size)
+        self.value = nn.Linear(config.hidden_size, self.all_head_size)
+
+        self.f_key = nn.Linear(config.get(feature_hidden_size), self.all_head_size) \
+            if not config.get(share_feature_keys) else None
+        self.f_value = nn.Linear(config.get(feature_hidden_size), self.all_head_size) \
+            if not config.get(share_feature_values) else None
+
+        self.dropout = nn.Dropout(config.attention_probs_dropout_prob)
+        self.position_embedding_type = position_embedding_type or getattr(
+            config, "position_embedding_type", "absolute"
+        )
+        if self.position_embedding_type == "relative_key" or self.position_embedding_type == "relative_key_query":
+            self.max_position_embeddings = config.max_position_embeddings
+            self.distance_embedding = nn.Embedding(2 * config.max_position_embeddings - 1, self.attention_head_size)
+
+    def transpose_for_scores(self, x: torch.Tensor) -> torch.Tensor:
+        new_x_shape = x.size()[:-1] + (self.num_attention_heads, self.attention_head_size)
+        x = x.view(new_x_shape)
+        return x.permute(0, 2, 1, 3)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        encoder_hidden_states: Optional[torch.FloatTensor] = None,
+        encoder_attention_mask: Optional[torch.FloatTensor] = None,
+        past_key_value: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+        output_attentions: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor]:
+
+        key_layer = self.transpose_for_scores(self.key(hidden_states))
+        value_layer = self.transpose_for_scores(self.value(hidden_states))
+        query_layer = self.transpose_for_scores(self.query(hidden_states))
+
+        use_cache = past_key_value is not None # should be None, not a decoder model 
+
+        # Take the dot product between "query" and "key" to get the raw attention scores.
+        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+
+        if self.position_embedding_type == "relative_key" or self.position_embedding_type == "relative_key_query":
+            query_length, key_length = query_layer.shape[2], key_layer.shape[2]
+            if use_cache:
+                position_ids_l = torch.tensor(key_length - 1, dtype=torch.long, device=hidden_states.device).view(
+                    -1, 1
+                )
+            else:
+                position_ids_l = torch.arange(query_length, dtype=torch.long, device=hidden_states.device).view(-1, 1)
+            position_ids_r = torch.arange(key_length, dtype=torch.long, device=hidden_states.device).view(1, -1)
+            distance = position_ids_l - position_ids_r
+
+            positional_embedding = self.distance_embedding(distance + self.max_position_embeddings - 1)
+            positional_embedding = positional_embedding.to(dtype=query_layer.dtype)  # fp16 compatibility
+
+            if self.position_embedding_type == "relative_key":
+                relative_position_scores = torch.einsum("bhld,lrd->bhlr", query_layer, positional_embedding)
+                attention_scores = attention_scores + relative_position_scores
+            elif self.position_embedding_type == "relative_key_query":
+                relative_position_scores_query = torch.einsum("bhld,lrd->bhlr", query_layer, positional_embedding)
+                relative_position_scores_key = torch.einsum("bhrd,lrd->bhlr", key_layer, positional_embedding)
+                attention_scores = attention_scores + relative_position_scores_query + relative_position_scores_key
+
+        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
+        if attention_mask is not None:
+            # Apply the attention mask is (precomputed for all layers in RobertaModel forward() function)
+            attention_scores = attention_scores + attention_mask
+
+        # Normalize the attention scores to probabilities.
+        attention_probs = nn.functional.softmax(attention_scores, dim=-1)
+        attention_probs = self.dropout(attention_probs)
+
+        # Mask heads if we want to
+        if head_mask is not None: 
+            attention_probs = attention_probs * head_mask
+
+        context_layer = torch.matmul(attention_probs, value_layer)
+
+        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
+        context_layer = context_layer.view(new_context_layer_shape)
+
+        # NOTE: Custom dual-attention to features (encoder_hidden_states)
+        if encoder_hidden_states is not None:
+
+            if self.f_key is not None: # no shared keys
+                encoder_key_layer = self.transpose_for_scores(self.f_key(encoder_hidden_states))
+            if self.f_value is not None: 
+                encoder_value_layer = self.transpose_for_scores(self.f_value(encoder_hidden_states))
+
+            # using the same token emb queries, we compute attention scores to our feature keys
+            encoder_attention_scores = torch.matmul(query_layer, encoder_key_layer.transpose(-1, -2))
+            encoder_attention_scores = encoder_attention_scores / math.sqrt(self.attention_head_size)
+
+            encoder_attention_probs = nn.functional.softmax(encoder_attention_scores, dim=-1)
+            encoder_attention_probs = self.dropout(encoder_attention_probs)
+
+            encoder_context_layer = torch.matmul(encoder_attention_probs, encoder_value_layer)
+
+            encoder_context_layer = encoder_context_layer.permute(0, 2, 1, 3).contiguous()
+            new_context_layer_shape = encoder_context_layer.size()[:-2] + (self.all_head_size,)
+            encoder_context_layer = encoder_context_layer.view(new_context_layer_shape)
+
+            # naively add these to the code context layer, as this is what is done to the residual
+            # `hidden_states` in the original SelfOutput module anyway. 
+            context_layer += encoder_context_layer
+
+        else: 
+            raise ValueError('JonbertaSelfAttention used without features (`encoder_hidden_states`).')
+
+        outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)
+        if output_attentions: 
+            raise ValueError('Output attentions not supported for Jonberta model, as we are applying feature attention too.')
+
+        # if self.is_decoder:
+        #     outputs = outputs + (past_key_value,)
+        #     raise ValueError('Jonberta is not a decoder model')
+
+        return outputs
+
+### Attention and Cross-Attention Modules. 
+# NOTE: may not be necessary, default Roberta implements cross-attn. 
+# However, it may not handle K, V weights properly as it is for sequences,
+# and not telemetry feature vectors.
+
+class JonbertaCrossAttention(nn.Module):
+    def __init__(self, config, layer_idx):
+        super().__init__()
+        # self.self = RobertaSelfAttention(config, position_embedding_type=position_embedding_type)
+        # self.output = RobertaSelfOutput(config)
+        self.self = ScaledCrossAttention(config, layer_idx=layer_idx) if \
+            not config.get(cross_attn_v2) else NonLinearCrossAttention(config, layer_idx)# Changed RobertaSelfAttention -> JonbertaCrossAttention
+        self.output = JonbertaSelfOutput(config)
+
+        self.pruned_heads = set()
+
+    def prune_heads(self, heads):
+        raise NotImplementedError('Pruning not (yet) implemented for Jonberta model')
+        # if len(heads) == 0:
+        #     return
+        # heads, index = find_pruneable_heads_and_indices(
+        #     heads, self.self.num_attention_heads, self.self.attention_head_size, self.pruned_heads
+        # )
+
+        # # Prune linear layers
+        # self.self.query = prune_linear_layer(self.self.query, index)
+        # self.self.key = prune_linear_layer(self.self.key, index)
+        # self.self.value = prune_linear_layer(self.self.value, index)
+        # self.output.dense = prune_linear_layer(self.output.dense, index, dim=1)
+
+        # # Update hyper params and store pruned heads
+        # self.self.num_attention_heads = self.self.num_attention_heads - len(heads)
+        # self.self.all_head_size = self.self.attention_head_size * self.self.num_attention_heads
+        # self.pruned_heads = self.pruned_heads.union(heads)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        encoder_hidden_states: Optional[torch.FloatTensor] = None,
+        encoder_attention_mask: Optional[torch.FloatTensor] = None,
+        past_key_value: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+        output_attentions: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor]:
+
+        self_outputs = self.self(
+            hidden_states,
+            attention_mask,
+            head_mask,
+            encoder_hidden_states,
+            encoder_attention_mask,
+            past_key_value,
+            output_attentions,
+        )
+        attention_output = self.output(self_outputs[0], hidden_states)
+        outputs = (attention_output,) + self_outputs[1:]  # add attentions if we output them
+        return outputs
+class NonLinearCrossAttention(nn.Module):
+    ''' Scaling embeddings (like below) may not be the best idea in transformers where so much 
+        attention is paid to explicit and implicit normalisation. So, instead, we learn
+        a wx+b function for each element in the embedding vector from the scalar feature.
+
+        In short: 
+        - Learn embeddings (and how they change as the feature scales) through Hadamard layer 
+        - Apply softmax to allow for non-linearity
+        - (potentially) repeat this process for more complex patterns to be learnt
+        - Apply LayerNorm for explicit normalisation of those values
+        - Decode into C dimension, given that we cannot learn 1M new parameters from 20k samples
+        - Optionally can support multiple heads 
+
+        Parameters for this layer:
+        - `config.num_telemetry_features`
+        - `config.hidden_size` is the dimension of the token embeddings (what is output)
+        - `config.num_cross_attn_heads` is the number of heads to use for $V$ in cross-attention
+        - `config.cross_attn_dropout_probs` is the dropout probability for cross-attention
+        - `config.share_values` is a boolean to share the weights across heads (learned in JonbertaEncoder)
+        '''
+
+    def __init__(self, config, layer_idx=None):
+        super().__init__()
+        if config.hidden_size % config.num_attention_heads != 0 and not hasattr(config, "embedding_size"):
+            raise ValueError(
+                f"The hidden size ({config.hidden_size}) is not a multiple of the number of attention "
+                f"heads ({config.num_attention_heads})"
+            )
+        if not config.get(feature_hidden_size):
+            raise ValueError('NonLinearCrossAttention requires a feature_hidden_size to learn the embeddings.')
+
+        self.layer_idx = layer_idx 
+
+        self.query = nn.Linear(config.feature_hidden_size, self.all_head_size) if \
+            not config.get(use_queries) else None
+        self.key = nn.Linear(config.feature_hidden_size, self.all_head_size) if \
+            not config.get(share_keys) else None
+        self.value = nn.Linear(config.feature_hidden_size, self.all_head_size) if \
+            not config.get(share_values) else None
+
+        # TODO: For now, let's assume the simplest case where no values are shared
+        # and we don't use queries as they they would imply a fully parallel transformer to this one
+
+        self.num_cross_attention_heads = config.num_cross_attn_heads
+        self.attention_head_size = int(config.num_telemetry_features / config.num_cross_attn_heads)
+        self.all_head_size = self.num_cross_attention_heads * self.attention_head_size
+
+        self.share_values = config.share_values
+        if not config.share_values: # first layer with cross-attn, so init shared vals 
+            self.value = Hadamard(config.num_telemetry_features, config.hidden_size)
+
+        self.dropout = nn.Dropout(config.cross_attn_dropout_probs)
+
+class ScaledCrossAttention(nn.Module):
+    ''' Cross-attention with feature embeddings scaled by the value of that feature. '''
+
+    def __init__(self, config, layer_idx=None):
+        super().__init__()
+        if config.hidden_size % config.num_attention_heads != 0 and not hasattr(config, "embedding_size"):
+            raise ValueError(
+                f"The hidden size ({config.hidden_size}) is not a multiple of the number of attention "
+                f"heads ({config.num_attention_heads})"
+            )
+
+        self.layer_idx = layer_idx 
+        self.qk = nn.Linear(config.hidden_size, config.num_telemetry_features)
+
+        # TODO: remove this MH logic, as we don't have multiple heads. 
+        self.num_cross_attention_heads = config.num_cross_attn_heads
+        assert self.num_cross_attention_heads == 1, "Only one cross-attention head is supported for now."
+        self.attention_head_size = int(config.num_telemetry_features / config.num_cross_attn_heads)
+        self.all_head_size = self.num_cross_attention_heads * self.attention_head_size
+
+        self.share_values = config.share_values
+        if not config.share_values: # first layer with cross-attn, so init shared vals 
+            self.value = Hadamard(config.num_telemetry_features, config.hidden_size)
+
+        self.dropout = nn.Dropout(config.cross_attn_dropout_probs)
+
+    def transpose_for_scores(self, x: torch.Tensor) -> torch.Tensor:
+        new_x_shape = x.size()[:-1] + (self.num_cross_attention_heads, self.attention_head_size)
+        x = x.view(new_x_shape)
+        return x.permute(0, 2, 1, 3)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        encoder_hidden_states: Optional[torch.FloatTensor] = None,
+        encoder_attention_mask: Optional[torch.FloatTensor] = None,
+        past_key_value: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+        output_attentions: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor]:
+
+        if not self.share_values: 
+            value_layer = self.value(encoder_hidden_states)
+            value_layer = value_layer.unsqueeze(1)
+            past_key_value = (None, value_layer)
+        else: 
+            value_layer = encoder_hidden_states
+
+        # weighted sum of features per embedded token vector
+        # query_layer = self.transpose_for_scores(self.query(hidden_states))
+        mixed_query_layer = self.qk(hidden_states)
+
+        # Take the dot product between "query" and "key" to get the raw attention scores.
+        # attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+        attention_scores = self.transpose_for_scores(mixed_query_layer)
+        # attention_scores = attention_scores / math.sqrt(self.attention_head_size)
+        attention_scores /= math.sqrt(attention_scores.size(-1))
+
+        if encoder_attention_mask is not None:
+            # Apply the attention mask is (precomputed for all layers in RobertaModel forward() function)
+            # attention_scores = attention_scores + encoder_attention_mask
+            raise ValueError('No need to mask a feature vector')
+
+        # Normalize the attention scores to probabilities.
+        attention_probs = nn.functional.softmax(attention_scores, dim=-1)
+        attention_probs = self.dropout(attention_probs)
+
+        if head_mask is not None: # Mask heads if we want to
+            # attention_probs = attention_probs * head_mask
+            raise ValueError('Jonberta does not have multiple heads: you do not want to mask')
+
+        context_layer = torch.matmul(attention_probs, value_layer)
+
+        # context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+        # new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
+        # context_layer = context_layer.view(new_context_layer_shape)
+        context_layer = context_layer.squeeze(1) # get rid of that one head dim
+
+        outputs = (context_layer, attention_probs) if output_attentions else (context_layer,)
+        outputs = outputs + (past_key_value,) # include for subsequent layers
+
+        return outputs
+
+# Copied from transformers.models.bert.modeling_bert.BertSelfOutput
+class JonbertaSelfOutput(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+
+        if config.add_dense_layer:
+            # with dense means more implicit regularisation, which can help because telemetry data is not at all regularised
+            # however, also comes at a penalty of 18k extra weights to train & store 
+            self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+
+        self.has_dense = config.add_dense_layer
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.dropout = nn.Dropout(config.cross_attn_dropout_probs)
+
+    def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
+
+        if self.has_dense: 
+            hidden_states = self.dense(hidden_states)
+
+        hidden_states = self.dropout(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+class JonbertaModel(RobertaModel):
+    ''' This model behaves as an encoder, but can take an additional feature sequence to pay attention to. 
+        This can work by either:
+
+        1. Extending the self-attention with learned feature Keys and Values. (`config.add_self_attn`)
+        2. Incorporating cross-attention layers, with learned Query-Key and Values. (`config.add_cross_attn`)
+            We combine Query-Key into one matrix, as features are always provided in the same order. 
+
+        .. _*Attention is all you need*: https://arxiv.org/abs/1706.03762 '''
+
+    def __init__(self, config, add_pooling_layer=True):
+        super(RobertaModel, self).__init__(config) # Changed super() -> super(RobertaModel, self)
+        self.config = config
+
+        self.embeddings = RobertaEmbeddings(config)
+        self.encoder = JonbertaEncoder(config) # Changed RobertaEncoder -> JonbertaEncoder
+
+        self.pooler = RobertaPooler(config) if add_pooling_layer else None # we don't use this
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+class JonbertaForSequenceClassification(RobertaPreTrainedModel):
+    ''' Custom Joint attention model for sequence classification. '''
+
+    def __init__(self, config):
+        
+        super().__init__(config) # Changed super() -> super(RobertaForSequenceClassification, self)
+        self.num_labels = config.num_labels
+
+        self.config = deepcopy(config) # create a copy otherwise saving breaks 
+        config.get = lambda *args: config_has(config, args)
+
+        self.roberta = JonbertaModel(config, add_pooling_layer=False) # Changed RobertaModel -> JonbertaModel
+        self.classifier = RobertaClassificationHead(config) \
+            if not config.get(add_head) else JobertaClassificationHead(config) 
+
+        self.add_features_in_head = config.get(add_head)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        token_type_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple[torch.Tensor], SequenceClassifierOutput]:
+        r"""
+        labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
+            config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
+            `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+        NOTE: added encoder_hidden_states to forward
+        """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        outputs = self.roberta(
+            input_ids,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            encoder_hidden_states=encoder_hidden_states, # NOTE: added encoder_hidden_states
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        sequence_output = outputs[0]
+        logits = self.classifier(sequence_output) if not self.add_features_in_head \
+            else self.classifier(sequence_output, telemetry_features=encoder_hidden_states)
+
+        loss = None
+        if labels is not None:
+            # move labels to correct device to enable model parallelism
+            labels = labels.to(logits.device)
+            if self.config.problem_type is None:
+                if self.num_labels == 1:
+                    self.config.problem_type = "regression"
+                elif self.num_labels > 1 and (labels.dtype == torch.long or labels.dtype == torch.int):
+                    self.config.problem_type = "single_label_classification"
+                else:
+                    self.config.problem_type = "multi_label_classification"
+
+            if self.config.problem_type == "regression":
+                loss_fct = MSELoss()
+                if self.num_labels == 1:
+                    loss = loss_fct(logits.squeeze(), labels.squeeze())
+                else:
+                    loss = loss_fct(logits, labels)
+            elif self.config.problem_type == "single_label_classification":
+                loss_fct = CrossEntropyLoss()
+                loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
+            elif self.config.problem_type == "multi_label_classification":
+                loss_fct = BCEWithLogitsLoss()
+                loss = loss_fct(logits, labels)
+
+        if not return_dict:
+            output = (logits,) + outputs[2:]
+            return ((loss,) + output) if loss is not None else output
+
+        return SequenceClassifierOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+class JobertaClassificationHead(RobertaClassificationHead):
+    """Head for sentence-level classification tasks."""
+
+    def __init__(self, config):
+
+        super(RobertaClassificationHead, self).__init__() 
+
+        if not config.get(add_dense) and not config.get(add_proj):
+            print('WARNING: both add_dense and add_proj are False, so this head will function like RoBERTa\'s')
+
+        # NOTE: added features 
+        self.add_dense = config.get(add_dense)
+        self.add_proj = config.get(add_proj)
+
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        classifier_dropout = (
+            config.classifier_dropout if config.classifier_dropout is not None else config.hidden_dropout_prob
+        )
+        self.dropout = nn.Dropout(classifier_dropout)
+        self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
+
+    def forward(self, features, telemetry_features=None, **kwargs):
+
+        if telemetry_features is None or \
+            not (self.add_dense or self.add_proj): 
+
+            x = features[:, 0, :]  # take <s> token (equiv. to [CLS]); shape (B, C) for T[0]
+            x = self.dropout(x)
+            x = self.dense(x)
+            x = torch.tanh(x)
+            x = self.out_proj(x)
+            return x 
+
+        # features: (batch_size, seq_len, hidden_size)
+        x = features[:, 0, :]  # take <s> token (equiv. to [CLS]); shape (B, C) for T[0] 
+        
+        # concatenate x and telemetry_features for DROPOUT (& dense)
+        if self.add_dense:
+            assert telemetry_features is not None, 'need to pass telemetry features as `encoder_hidden_states`'
+            x = torch.cat((x, telemetry_features), dim=1)
+
+        x = self.dropout(x)
+        x = self.dense(x)
+        x = torch.tanh(x)
+
+        # concatenate x and telemetry features for DROPOUT (& projection)
+        if self.add_proj and not self.add_dense: 
+            x = torch.cat((x, telemetry_features), dim=1)
+
+        x = self.dropout(x)
+        x = self.out_proj(x)
+
+        return x
+

--- a/code4me-server/src/query_filter.py
+++ b/code4me-server/src/query_filter.py
@@ -1,0 +1,207 @@
+import os, math, enum, torch, numpy as np
+
+from modeling_jonberta import JonbertaForSequenceClassification, add_features_to_model
+from transformers import TextClassificationPipeline, AutoTokenizer, AutoConfig
+from safetensors import safe_open
+
+MODELS_DIR = 'models'
+DEVICE = 1 if torch.cuda.is_available() else -1 
+
+
+intercept, coef = 3.73303724, np.array([ 0.00860799, -0.03679135, -0.06289737,  0.4488578 , -0.40977991, -0.57503621, -0.41543147,  0.02215769, -0.56694562,  0.62073879, -0.26658544, -0.33758971, -0.19398661,  0.10083877,  0.29011958, 0.01642904,  0.082694  , -0.45812433,  0.19563108,  1.11585148, -0.12549902, -0.03319017,  0.        ,  0.37221593,  0.20887294, 0.59667318, -0.76727645, -2.23206534,  0.        ,  0.        , 0.        ,  0.        , -0.52622741, -1.80321186, -0.65761382, -0.66972758,  0.        , -2.12369698, -3.08559028, -2.64399433, -2.17775627, -0.72525643, -1.94062537, -0.64899621,  0.        , 0.07055691,  0.        ,  0.        ,  0.        ,  0.        , 0.        ,  0.        ,  0.        ,  0.        , -4.80829315, -2.20680964, -3.35584853, -3.23677452,  0.        ,  0.        , 0.16874269,  0.46803166,  0.6497761 ,  0.52477345,  0.5324576 , 0.51661321,  0.33516685,  0.27858223,  0.39369077,  0.1905836 , 0.11973277,  0.3743934 ,  0.40315233,  0.48388634,  0.32372177, 0.6324842 ,  0.09022166,  0.38000563,  0.4746545 ,  0.54397314, 0.22015718,  0.11972259,  0.33946541,  0.29087561,  0.16096189, 0.18354135, -1.20029481,  0.03437284,  0.08835093, -1.75083818, 0.97368022,  0.        ,  1.54601348,  0.72473379,  1.00326585, 1.8238706 ,  2.44167387,  1.74815122,  0.79420007,  1.53473857, 1.08563755,  0.53734968,  0.55176486,  0.98191938,  0.90612076, 1.81525461,  1.21869578,  1.07433351,  0.40708646,  2.276902  , 1.85239634,  2.01438915,  0.77927204,  0.67669704,  0.69432173, 0.72461073,  0.75737211,  0.27126203, -2.08431261, -1.47177109, 0.02996505, -0.47417774,  0.        ,  0.        ,  0.        , 0.        ,  0.        , -0.964373  , -0.84868705, -0.65761382, -1.42460126,  0.        , -1.47293568, -0.94525298, -0.60052356, -1.12780257, -1.92249699, -1.66530837, -0.64899621,  0.        , 0.07055691,  0.        ,  0.        ,  0.        ,  0.        , 0.        ,  0.        ,  0.        ,  0.        , -1.35681768, -0.80897361, -0.16270093, -0.69864107,  0.        ,  0.        , 0.16874269,  0.46803166,  0.6497761 ,  0.52477345,  0.5324576 , 0.51661321,  0.33516685,  0.27858223,  0.39369077,  0.1905836 , 0.11973277,  0.3743934 ,  0.40315233,  0.48388634, -0.0571159 , 0.6324842 ,  0.09022166,  0.38000563,  0.4746545 ,  0.54397314, 0.22015718,  0.11972259,  0.33946541,  0.29087561,  0.16096189, 0.18354135, -1.79744913,  0.03437284,  0.08835093, -1.75083818, 0.97368022,  0.        ,  0.33769289,  0.72473379,  1.00326585, -0.47593682, -0.28913642, -0.47461482,  0.79420007, -1.07146562, 1.08563755,  0.53734968,  0.55176486,  1.25787508,  0.90612076, -0.05355035,  0.74789048,  1.07433351,  0.40708646, -0.71501723, -0.04197237,  0.10833025,  0.77927204,  0.67669704,  0.75031618, 0.72461073,  0.75737211,  0.27126203, -1.3740823 , -1.18380704, 0.02996505, -0.47417774])
+tokenizer = AutoTokenizer.from_pretrained('huggingface/CodeBERTa-small-v1')
+
+from transformers import set_seed 
+import random 
+def set_all_seeds(seed=42):
+    set_seed(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    # torch.distributed.barrier()
+
+
+class Logres:
+
+    SUPPORTED_LANGS = [
+        'javascript', 'typescript', 'typescriptreact', 'python', 'vue', 'php', 'dart', 
+        'javascriptreact', 'go', 'css', 'cpp', 'html', 'scss', 'markdown', 'csharp', 
+        'java', 'json', 'rust', 'ruby', 'c',
+    ]
+
+    def __init__(self, weights, intercept):
+        self.weights = weights
+        self.intercept = intercept
+
+    @classmethod
+    def character_map(cls, char) -> list:
+        ''' Converts a character code (32-127) to one-hot vector '''
+        char_code = ord(char)
+        return [1 if char_code == i else 0 for i in range(32, 127)]
+
+    @classmethod 
+    def lang_map(cls, query_lang) -> list:
+        ''' Converts a supported language to one-hot vector '''
+        return [1 if query_lang == lang else 0 for lang in cls.SUPPORTED_LANGS]
+
+    def _preprocess(self, X: dict) -> np.array: 
+        ''' Preprocess a query into a vector of features '''
+
+        document_length = len(X['prefix']) + len(X['suffix'])
+        offset = len(X['prefix'])
+        offset_percentage = offset / document_length
+        whitespace_after_cursor = 1 if (len(X['suffix']) >= 1 and X['suffix'][0] == ' ') else 0
+        last_prefix_line = X['prefix'].split('\n')[-1]
+        last_prefix_line_stripped = last_prefix_line.rstrip()
+
+        return np.array([
+            math.log(1 + X['time_since_last_completion']),
+            math.log(1 + document_length),
+            math.log(1 + offset),
+            offset_percentage,
+            *self.lang_map(X['language']),
+            whitespace_after_cursor,
+            math.log(1 + len(last_prefix_line)),
+            math.log(1 + len(last_prefix_line_stripped)),
+            *self.character_map(last_prefix_line[-1] if len(last_prefix_line) > 0 else chr(0)),
+            *self.character_map(last_prefix_line_stripped[-1] if len(last_prefix_line_stripped) > 0 else chr(0)),
+        ])
+
+    def predict(self, X: dict) -> bool: 
+        X = self._preprocess(X)
+        should_filter = X @ self.weights + self.intercept > 0  # True means positive class
+        # important to wrap this in bool for json serialisation!
+        return not bool(should_filter) # True means to filter out
+
+def get_nontextual_features(query) -> list:
+    ''' Get the features that could otherwise not be extracted from the context alone '''
+
+    offset = len(query['prefix'])
+    document_length = offset + len(query['suffix'])
+
+    return [
+        1 if query['ide'] == 'jetbrains' else 0,           
+        1 if query['ide'] == 'vsc' else 0,                 
+        math.log(1 + query['time_since_last_completion']), 
+        math.log(1 + document_length),      
+        math.log(1 + offset),               
+        offset / document_length,           
+        *Logres.lang_map(query['language']),  
+    ]
+
+def tokenize_joint_sample(sample, max_suffix_tokens=128):
+    ''' For a single sample, tokenize prefix and suffix, separating by </s> sep token. 
+    Set max_suffix_tokens to maximal amount of suffix to include, when it exists. '''
+
+    max_length = tokenizer.model_max_length # 512 
+
+    # figure out how many suffix tokens we have (128 max)
+    tokenizer.truncation_side = 'right'
+    suffix = tokenizer(sample['suffix'], padding='do_not_pad', truncation=True, return_tensors='pt',
+                        max_length = max_suffix_tokens + 1) # to accomodate removal of <s>
+
+    n_suffix_tokens = len(suffix['input_ids'][0]) - 1
+
+    tokenizer.truncation_side = 'left'
+    prefix = tokenizer(sample['prefix'], padding='do_not_pad', truncation=True, return_tensors='pt',
+                    max_length = max_length - n_suffix_tokens)
+
+    n_prefix_tokens = len(prefix['input_ids'][0])
+    tokenizer.truncation_side = 'right'
+    suffix = tokenizer(sample['suffix'], padding='max_length', truncation=True, return_tensors='pt',
+                    max_length = max_length - n_prefix_tokens + 1) # to accomodate removal of <s>
+    
+    suffix['input_ids'] = suffix['input_ids'][:, 1:]
+    suffix['attention_mask'] = suffix['attention_mask'][:, 1:]
+
+    sample.update({k: torch.cat((prefix[k], suffix[k]), dim=1) for k in prefix})
+    return sample
+
+
+class MyPipeline(TextClassificationPipeline):
+    ''' oh yeah custom pipeline because of the custom tokenisation!
+        how convenient huggingface ill hug your face extra hard next time i see you '''
+
+    def __init__(self, *args, incl_features=True, preprocess_fn=tokenize_joint_sample, model_name=None, **kwargs):
+        if 'device' in kwargs and 'model' in kwargs: 
+            print(f'\tusing device \033[1m{kwargs["device"]}\033[0m for model \033[1m{model_name}\033[0m')
+        super().__init__(*args, **kwargs)
+        self.incl_features = incl_features
+        self.preprocess_fn = preprocess_fn
+
+    def _sanitize_parameters(self, **kwargs):
+        preprocess_kwargs = {} 
+        if 'preprocess_fn' in kwargs: 
+            preprocess_kwargs['preprocess_fn'] = kwargs.pop('preprocess_fn')
+        return preprocess_kwargs, {}, {} 
+    
+    def preprocess(self, inputs, preprocess_fn=None):
+        inputs = {
+            'prefix': inputs['prefix'], 
+            'suffix': inputs['suffix'], 
+            'encoder_hidden_states': get_nontextual_features(inputs)
+        }
+        inputs = preprocess_fn(inputs) if self.preprocess_fn is None else self.preprocess_fn(inputs)
+        if 'prefix' in inputs: del inputs['prefix']
+        if 'suffix' in inputs: del inputs['suffix']
+        # given that pipeline is used in sequential eval, we neeed to add a batch dimension for the model to not throw a tantrum
+        if self.incl_features:
+            inputs['encoder_hidden_states'] = torch.tensor(inputs['encoder_hidden_states'], dtype=torch.float32).unsqueeze(0)
+        elif 'encoder_hidden_states' in inputs: 
+            del inputs['encoder_hidden_states']
+        return inputs
+
+    def _forward(self, model_inputs):
+        return self.model(**model_inputs)
+
+    def postprocess(self, model_outputs) -> bool:
+        prediction = model_outputs.logits.argmax(-1).item() == 1 # 1 is the positive class
+        return not bool(prediction) # True means to filter out
+
+def get_model(model_name):
+    model_dir = os.path.join(MODELS_DIR, model_name)
+    config = AutoConfig.from_pretrained(model_dir)
+
+    model = JonbertaForSequenceClassification(config)
+    if hasattr(config, 'add_head') and config.add_head: 
+        add_features_to_model(model, config)
+
+    # ah yes huggingface is a 5 BILLION dollar company now
+    state_dict = {} 
+    with safe_open(os.path.join(model_dir, 'model.safetensors'), framework='pt') as f: 
+        for key in f.keys():
+            state_dict[key] = f.get_tensor(key)
+    new_layers = model.load_state_dict(state_dict, strict=False)
+    print(f'''incompatible keys during loading: {new_layers}. 
+          I don\'t know why this happens, I can't reproduce it locally 
+          As long as it's just embedding position ids, it should be fine.''') 
+
+    return model 
+
+class Filter(enum.Enum):
+    FEATURE = 'feature'
+    CONTEXT = 'context'
+    JOINT_H = 'joint_h'
+    JOINT_A = 'joint_a'
+
+logres = Logres(coef, intercept)
+set_all_seeds() # just in case 
+context_filter = MyPipeline( device=DEVICE, task='text-classification',
+                    model=get_model('12_codeberta-biased-2e-05lr--0'), incl_features=True,
+                    model_name='12_codeberta-biased-2e-05lr--0' )
+set_all_seeds()
+joint_h_filter = MyPipeline( device=DEVICE, task='text-classification',
+                    model=get_model('-13_jonberta-biased-12_codeberta-biased-2e-05lr--0-(HEAD-dense--reinit)-2e-05lr-1'), incl_features=True,
+                    model_name='-13_jonberta-biased-12_codeberta-biased-2e-05lr--0-(HEAD-dense--reinit)-2e-05lr-1' )
+set_all_seeds()
+joint_a_filter = MyPipeline( device=DEVICE, task='text-classification',
+                    model=get_model('13_jonberta-biased-12_codeberta-biased-2e-05lr--0-(ATTN-208C_f-[0]L)-2e-05lr--4'), incl_features=True,
+                    model_name='13_jonberta-biased-12_codeberta-biased-2e-05lr--0-(ATTN-208C_f-[0]L)-2e-05lr--4' )
+
+filters = {
+    Filter.FEATURE: logres.predict,
+    Filter.CONTEXT: context_filter,
+    Filter.JOINT_H: joint_h_filter,
+    Filter.JOINT_A: joint_a_filter,
+}

--- a/code4me-server/src/user_study.py
+++ b/code4me-server/src/user_study.py
@@ -1,0 +1,91 @@
+import os, enum, random, json
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Tuple, Callable
+
+# SESSION_TIMEOUT = 1800  # 30 minutes
+SESSION_TIMEOUT = 5
+MAX_CACHE_SIZE = 30
+STUDY_VERSION = '0.0.1'
+
+USER_STUDY_DIR = 'data_aral'
+os.makedirs(USER_STUDY_DIR, exist_ok=True)
+
+class Filter(enum.Enum):
+    CONTEXT = 'context'
+    FEATURE = 'feature'
+    JOINT   = 'joint'
+
+filters = {
+    Filter.CONTEXT: lambda: 1,
+    Filter.FEATURE: lambda: 0,
+    Filter.JOINT:   lambda: 0, 
+}
+
+# Cache of user_uuid -> (last_access, filter_type)
+# which allows us to retrieve the Filter predict function via filters[filter_type]
+cache = {}  # We only have like 100 concurrent users at a time, so in-memory it is 
+
+
+def get_request_filter(user_uuid: str, time: datetime) -> Callable[[dict], bool]: 
+    ''' A user is assigned the same filter while in a session, i.e. if it is no longer than 
+        30 mins since the last completion. Otherwise, they are assigned a filter at random '''
+    
+    filter_type = cache[user_uuid][1] \
+        if user_uuid in cache and (time - cache[user_uuid][0]).seconds < SESSION_TIMEOUT \
+        else random.choice(list(filters.keys()))
+
+    cache[user_uuid] = (time, filter_type)
+    if len(cache) > MAX_CACHE_SIZE: prune_cache(time)
+
+    return filters[filter_type]
+
+def prune_cache(time: datetime):
+    ''' Prune cache of users with expired sessions, or update MAX_CACHE_SIZE to grow 
+        proportionally. I.e. minimise memory while ensuring all users are kept track of '''
+    
+    global MAX_CACHE_SIZE
+    
+    for user_uuid, (last_access, _) in cache.items():
+        if (time - last_access).seconds > SESSION_TIMEOUT:
+            del cache[user_uuid]
+
+    if len(cache) > MAX_CACHE_SIZE:
+        new_size = len(cache) + MAX_CACHE_SIZE
+        print(f'Growing cache to size {new_size}')
+        MAX_CACHE_SIZE = new_size 
+    elif len(cache) < MAX_CACHE_SIZE // 2:
+        new_size = MAX_CACHE_SIZE // 2
+        print(f'Shrinking cache to size {new_size}')
+        MAX_CACHE_SIZE = new_size
+    else: 
+        print(f"Pruned cache to size {len(cache)}")
+
+def filter_request(user_uuid: str, completion_request: dict) -> Tuple[float, bool]:
+    ''' Call the request filter (point of this study), returning the time taken and 
+        whether the request should be filtered. '''
+
+    t0 = datetime.now()
+    filter_fn = get_request_filter(user_uuid, t0)
+    should_filter = filter_fn(completion_request)
+    time = (datetime.now() - t0).total_seconds() * 1000
+
+    return time, should_filter
+
+def store_completion_request(user_uuid: str, verify_token: str, completion_request: dict):
+    ''' Store the completion request in USER_STUDY_DIR/user_uuid/verify_token.json '''
+
+    user_dir = os.path.join(USER_STUDY_DIR, user_uuid)
+    json_file = f'{verify_token}.json'
+    os.makedirs(user_dir, exist_ok=True)
+
+    with open(os.path.join(user_dir, json_file), 'w') as f:
+        f.write(json.dumps(completion_request))
+
+def should_prompt_survey(user_uuid: str):
+    ''' Return whether to prompt the user with survey. I re-specify it here, 
+        as it depends on `USER_STUDY_DIR` '''
+
+    n_suggestions = len(os.listdir(os.path.join(USER_STUDY_DIR, user_uuid)))
+    return n_suggestions >= 100 and n_suggestions % 50 == 0

--- a/code4me-server/src/user_study.py
+++ b/code4me-server/src/user_study.py
@@ -18,9 +18,9 @@ class Filter(enum.Enum):
     JOINT   = 'joint'
 
 filters = {
-    Filter.CONTEXT: lambda: 1,
-    Filter.FEATURE: lambda: 0,
-    Filter.JOINT:   lambda: 0, 
+    Filter.CONTEXT: lambda request_json: 1,
+    Filter.FEATURE: lambda request_json: 0,
+    Filter.JOINT:   lambda request_json: 0, 
 }
 
 # Cache of user_uuid -> (last_access, filter_type)
@@ -87,5 +87,8 @@ def should_prompt_survey(user_uuid: str):
     ''' Return whether to prompt the user with survey. I re-specify it here, 
         as it depends on `USER_STUDY_DIR` '''
 
-    n_suggestions = len(os.listdir(os.path.join(USER_STUDY_DIR, user_uuid)))
+    user_dir = os.path.join(USER_STUDY_DIR, user_uuid)
+    if not os.path.exists(user_dir): return False
+
+    n_suggestions = len(os.listdir(user_dir))
     return n_suggestions >= 100 and n_suggestions % 50 == 0

--- a/code4me-vsc-plugin/.vscode/tasks.json
+++ b/code4me-vsc-plugin/.vscode/tasks.json
@@ -1,16 +1,42 @@
+// {
+// 	"version": "2.0.0",
+// 	"tasks": [
+// 		{
+// 			"type": "npm",
+// 			"script": "compile",
+// 			"group": {
+// 				"kind": "build",
+// 				"isDefault": true
+// 			},
+// 			"problemMatcher": [],
+// 			"label": "npm: compile",
+// 			"detail": "tsc -p ./"
+// 		}
+// 	]
+// }
+
+// NOTE: Not sure how the above came about. 
+// It prevents the plugin from hot-reloading when developing. 
+// The below is the correct configuration for the tasks.json file according to vscode themselves. 
+// Specifically, `"script": "compile"` should be `"script": "watch"` to, you guessed it, watch for changes!
+
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
 {
 	"version": "2.0.0",
 	"tasks": [
 		{
 			"type": "npm",
-			"script": "compile",
+			"script": "watch",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
 			"group": {
 				"kind": "build",
 				"isDefault": true
-			},
-			"problemMatcher": [],
-			"label": "npm: compile",
-			"detail": "tsc -p ./"
+			}
 		}
 	]
 }

--- a/code4me-vsc-plugin/README.md
+++ b/code4me-vsc-plugin/README.md
@@ -1,26 +1,27 @@
 # Code4Me
 
 <!-- Plugin description -->
-**Code4Me** provides language model based code completion. Code4Me predicts statement (line) completion and is seemlessly integrated with Visual Studio Code's code completion. The code suggestions from Code4Me are denoted with a unicode "&#10094;&#65295;&#10095;" representation of the logo. Code for me triggers automatically but can also be prompted manually by pressing your keybind for autocompletion (trigger suggest command).
+**Code4Me** provides AI-generated line completions, and is seamlessly integrated with VSCode's IntelliSense completions. You can also manually trigger completions using `⌃Space`. 
 
-Code4Me does not hinder native auto completion or other extensions. For more information, visit the [Code4Me](https://code4me.me) website.
+The code suggestions from Code4Me are denoted with a unicode "&#10094;&#65295;&#10095;" representation of the logo. Code4Me does not hinder native auto completion or other extensions. For more information, visit the [Code4Me](https://code4me.me) website.
 <!-- Plugin description end -->
 
 # Goal
-Code4Me is made by bachelor students at [Delft University of Technology](https://www.tudelft.nl/). Code4Me is a supportive tool to gather data about auto-completion models and their usefulness. This data is then analysed and discussed in a BSc thesis.
+Code4Me exists for research purposes at the [Delft University of Technology](https://www.tudelft.nl/). Code4Me is a supportive tool to gather data about auto-completion models and their usefulness. 
 
 ## Data Collection
-The plugin does **not** collect identifiable data. The plugin does collect the following data:
+The plugin does **not** collect identifiable data. The plugin does collect the following *anonymised* usage data: 
 
-* Suggest insertion.
-* Verified insertion.
+- Close context around the cursor. 
+- The generated completion, and whether it was accepted. 
+- Verified insertion.
   - The plugin tracks the line the code was inserted and sends that line to the server after a timeout.
-* Time of completion.
+- Time of completion.
 
-### Optional Data Collection
-To perform a failure analysis & improve code4me, we would like to store the close context before completions. This, however, is an **optional** setting and is turned off by default. We do not store the context around completions without explicit approval. This request is prompted upon start-up.
+Code4Me is in full compliance with the GDPR. The data collected will remain on the servers of TU Delft until the end of the study; and will not be published. By using Code4Me, you give permission for data collection. Thank you for supporting open-source research!
 
-Code4Me is in full compliance with the GDPR and all data is anonymous. The data collected will remain on the servers of TU Delft until the end of the study. By using Code4Me you give permission for data collection. 
+<!-- ### Optional Data Collection -->
+<!-- To perform a failure analysis & improve code4me, we would like to store the close context before completions. This, however, is an **optional** setting and is turned off by default. We do not store the context around completions without explicit approval. This request is prompted upon start-up. -->
 
-# Transmitted Code
-To allow for code suggestions code (3992 characters left and right of trigger position) is send to servers at the TU Delft and processed. In return a code completion is send back. The sent code is not saved on the database.
+<!-- # Transmitted Code
+To allow for code suggestions code (3992 characters left and right of trigger position) is send to servers at the TU Delft and processed. In return a code completion is send back.  -->

--- a/code4me-vsc-plugin/package-lock.json
+++ b/code4me-vsc-plugin/package-lock.json
@@ -1,15 +1,40 @@
 {
 	"name": "code4me-plugin",
 	"version": "1.0.9",
-	"lockfileVersion": 1,
+	"lockfileVersion": 3,
 	"requires": true,
-	"dependencies": {
-		"@eslint/eslintrc": {
+	"packages": {
+		"": {
+			"name": "code4me-plugin",
+			"version": "1.0.9",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"csprng": "^0.1.2",
+				"node-fetch": "^2.6.7",
+				"uuid": "^8.3.2"
+			},
+			"devDependencies": {
+				"@types/csprng": "^0.1.2",
+				"@types/node": "^12.12.0",
+				"@types/node-fetch": "^2.6.1",
+				"@types/uuid": "^8.3.4",
+				"@types/vscode": "^1.47.0",
+				"@typescript-eslint/eslint-plugin": "^5.19.0",
+				"@typescript-eslint/parser": "^5.19.0",
+				"eslint": "^8.13.0",
+				"typescript": "^4.6.3",
+				"vscode-dts": "^0.3.3"
+			},
+			"engines": {
+				"vscode": "^1.47.0"
+			}
+		},
+		"node_modules/@eslint/eslintrc": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
 			"integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
 				"espree": "^9.3.1",
@@ -19,97 +44,112 @@
 				"js-yaml": "^4.1.0",
 				"minimatch": "^3.0.4",
 				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"@humanwhocodes/config-array": {
+		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.9.5",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
 			"integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
 				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=10.10.0"
 			}
 		},
-		"@humanwhocodes/object-schema": {
+		"node_modules/@humanwhocodes/object-schema": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@nodelib/fs.scandir": {
+		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"@nodelib/fs.stat": {
+		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
 		},
-		"@nodelib/fs.walk": {
+		"node_modules/@nodelib/fs.walk": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"@types/csprng": {
+		"node_modules/@types/csprng": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@types/csprng/-/csprng-0.1.2.tgz",
 			"integrity": "sha512-QJdNKn4a5JfDcIQLaVjKcVFhm9Es8U8kMOwPYof3TDO5CjLodooAYdGy+pAShgefOwe0bRextBLO5gC0k3Q3Iw==",
 			"dev": true
 		},
-		"@types/json-schema": {
+		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
-		"@types/node": {
+		"node_modules/@types/node": {
 			"version": "12.20.52",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
 			"integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==",
 			"dev": true
 		},
-		"@types/node-fetch": {
+		"node_modules/@types/node-fetch": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.1.tgz",
 			"integrity": "sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/node": "*",
 				"form-data": "^3.0.0"
 			}
 		},
-		"@types/uuid": {
+		"node_modules/@types/uuid": {
 			"version": "8.3.4",
 			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
 			"integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
 			"dev": true
 		},
-		"@types/vscode": {
+		"node_modules/@types/vscode": {
 			"version": "1.67.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
 			"integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
 			"dev": true
 		},
-		"@typescript-eslint/eslint-plugin": {
+		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.19.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
 			"integrity": "sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.19.0",
 				"@typescript-eslint/type-utils": "5.19.0",
 				"@typescript-eslint/utils": "5.19.0",
@@ -119,53 +159,113 @@
 				"regexpp": "^3.2.0",
 				"semver": "^7.3.5",
 				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^5.0.0",
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/parser": {
+		"node_modules/@typescript-eslint/parser": {
 			"version": "5.19.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.19.0.tgz",
 			"integrity": "sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.19.0",
 				"@typescript-eslint/types": "5.19.0",
 				"@typescript-eslint/typescript-estree": "5.19.0",
 				"debug": "^4.3.2"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/scope-manager": {
+		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "5.19.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz",
 			"integrity": "sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.19.0",
 				"@typescript-eslint/visitor-keys": "5.19.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"@typescript-eslint/type-utils": {
+		"node_modules/@typescript-eslint/type-utils": {
 			"version": "5.19.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz",
 			"integrity": "sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/utils": "5.19.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/types": {
+		"node_modules/@typescript-eslint/types": {
 			"version": "5.19.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.19.0.tgz",
 			"integrity": "sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
 		},
-		"@typescript-eslint/typescript-estree": {
+		"node_modules/@typescript-eslint/typescript-estree": {
 			"version": "5.19.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz",
 			"integrity": "sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.19.0",
 				"@typescript-eslint/visitor-keys": "5.19.0",
 				"debug": "^4.3.2",
@@ -173,230 +273,331 @@
 				"is-glob": "^4.0.3",
 				"semver": "^7.3.5",
 				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"@typescript-eslint/utils": {
+		"node_modules/@typescript-eslint/utils": {
 			"version": "5.19.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.19.0.tgz",
 			"integrity": "sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"@typescript-eslint/scope-manager": "5.19.0",
 				"@typescript-eslint/types": "5.19.0",
 				"@typescript-eslint/typescript-estree": "5.19.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"@typescript-eslint/visitor-keys": {
+		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "5.19.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz",
 			"integrity": "sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@typescript-eslint/types": "5.19.0",
 				"eslint-visitor-keys": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"acorn": {
+		"node_modules/acorn": {
 			"version": "8.7.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
 			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"acorn-jsx": {
+		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true
+			"dev": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
 		},
-		"ajv": {
+		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"ansi-regex": {
+		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"ansi-styles": {
+		"node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"argparse": {
+		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"array-union": {
+		"node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"asynckit": {
+		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
-		"balanced-match": {
+		"node_modules/balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
-		"brace-expansion": {
+		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
-		"braces": {
+		"node_modules/braces": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"fill-range": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"callsites": {
+		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"chalk": {
+		"node_modules/chalk": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
 			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"color-convert": {
+		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
 			}
 		},
-		"color-name": {
+		"node_modules/color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"combined-stream": {
+		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
-		"concat-map": {
+		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"cross-spawn": {
+		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"csprng": {
+		"node_modules/csprng": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/csprng/-/csprng-0.1.2.tgz",
 			"integrity": "sha1-S8aPEvo2jSUqWYQcusqXSxirReI=",
-			"requires": {
+			"dependencies": {
 				"sequin": "*"
+			},
+			"engines": {
+				"node": ">=0.6.0"
 			}
 		},
-		"debug": {
+		"node_modules/debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
 			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
-		"deep-is": {
+		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
-		"delayed-stream": {
+		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"dir-glob": {
+		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"doctrine": {
+		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
-		"escape-string-regexp": {
+		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"eslint": {
+		"node_modules/eslint": {
 			"version": "8.13.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
 			"integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@eslint/eslintrc": "^1.2.1",
 				"@humanwhocodes/config-array": "^0.9.2",
 				"ajv": "^6.10.0",
@@ -433,766 +634,1059 @@
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
 			},
-			"dependencies": {
-				"eslint-scope": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-					"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.3.0",
-						"estraverse": "^5.2.0"
-					}
-				},
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"eslint-scope": {
+		"node_modules/eslint-scope": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
-		"eslint-utils": {
+		"node_modules/eslint-utils": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
 			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"eslint-visitor-keys": "^2.0.0"
 			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-					"dev": true
-				}
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
 			}
 		},
-		"eslint-visitor-keys": {
+		"node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
 			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
 		},
-		"espree": {
+		"node_modules/eslint/node_modules/eslint-scope": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/espree": {
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
 			"integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"acorn": "^8.7.0",
 				"acorn-jsx": "^5.3.1",
 				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"esquery": {
+		"node_modules/esquery": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
 			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
-		"esrecurse": {
+		"node_modules/esquery/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esrecurse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
-		"estraverse": {
+		"node_modules/esrecurse/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
 		},
-		"esutils": {
+		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"fast-deep-equal": {
+		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
-		"fast-glob": {
+		"node_modules/fast-glob": {
 			"version": "3.2.11",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
 			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
 				"micromatch": "^4.0.4"
 			},
-			"dependencies": {
-				"glob-parent": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				}
+			"engines": {
+				"node": ">=8.6.0"
 			}
 		},
-		"fast-json-stable-stringify": {
+		"node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
-		"fast-levenshtein": {
+		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
-		"fastq": {
+		"node_modules/fastq": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
 			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"reusify": "^1.0.4"
 			}
 		},
-		"file-entry-cache": {
+		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"flat-cache": "^3.0.4"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"fill-range": {
+		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"flat-cache": {
+		"node_modules/flat-cache": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
 			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"flatted": {
+		"node_modules/flatted": {
 			"version": "3.2.5",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
 			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
 		},
-		"form-data": {
+		"node_modules/form-data": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
 			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"fs.realpath": {
+		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
-		"functional-red-black-tree": {
+		"node_modules/functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
-		"glob": {
+		"node_modules/glob": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
 			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"glob-parent": {
+		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
-		"globals": {
+		"node_modules/globals": {
 			"version": "13.13.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
 			"integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"globby": {
+		"node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
 				"fast-glob": "^3.2.9",
 				"ignore": "^5.2.0",
 				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"has-flag": {
+		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"ignore": {
+		"node_modules/ignore": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
 			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
 		},
-		"import-fresh": {
+		"node_modules/import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"imurmurhash": {
+		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
 		},
-		"inflight": {
+		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
 			}
 		},
-		"inherits": {
+		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
-		"is-extglob": {
+		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"is-glob": {
+		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
-		"is-number": {
+		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
+			}
 		},
-		"isexe": {
+		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
 		},
-		"js-yaml": {
+		"node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"json-schema-traverse": {
+		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
-		"json-stable-stringify-without-jsonify": {
+		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
 		},
-		"kleur": {
+		"node_modules/kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"levn": {
+		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"lodash.merge": {
+		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"lru-cache": {
+		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
-		"merge2": {
+		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
 		},
-		"micromatch": {
+		"node_modules/micromatch": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
 			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
 			}
 		},
-		"mime-db": {
+		"node_modules/mime-db": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
-		"mime-types": {
+		"node_modules/mime-types": {
 			"version": "2.1.35",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
-		"minimatch": {
+		"node_modules/minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
-		"minimist": {
+		"node_modules/minimist": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
 			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
-		"ms": {
+		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
-		"natural-compare": {
+		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"node-fetch": {
+		"node_modules/node-fetch": {
 			"version": "2.6.7",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
 			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-			"requires": {
+			"dependencies": {
 				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
 			}
 		},
-		"once": {
+		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"wrappy": "1"
 			}
 		},
-		"optionator": {
+		"node_modules/optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
 			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
 				"type-check": "^0.4.0",
 				"word-wrap": "^1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"parent-module": {
+		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
-		"path-is-absolute": {
+		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"path-key": {
+		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"path-type": {
+		"node_modules/path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"picomatch": {
+		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
 		},
-		"prelude-ls": {
+		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
 		},
-		"prompts": {
+		"node_modules/prompts": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
 			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"kleur": "^3.0.3",
 				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"punycode": {
+		"node_modules/punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"queue-microtask": {
+		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
-		"regexpp": {
+		"node_modules/regexpp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
 		},
-		"resolve-from": {
+		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"reusify": {
+		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
 		},
-		"rimraf": {
+		"node_modules/rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"run-parallel": {
+		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
 			"dev": true,
-			"requires": {
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"semver": {
+		"node_modules/semver": {
 			"version": "7.3.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
 			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
-		"sequin": {
+		"node_modules/sequin": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/sequin/-/sequin-0.1.1.tgz",
-			"integrity": "sha1-XC04nWajg3NOqvvEXt6ywcsb5wE="
+			"integrity": "sha1-XC04nWajg3NOqvvEXt6ywcsb5wE=",
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"shebang-command": {
+		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"shebang-regex": {
+		"node_modules/shebang-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"sisteransi": {
+		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
 			"dev": true
 		},
-		"slash": {
+		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
-		"strip-ansi": {
+		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"strip-json-comments": {
+		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"supports-color": {
+		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"text-table": {
+		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
 		},
-		"to-regex-range": {
+		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
 			}
 		},
-		"tr46": {
+		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
 		},
-		"tslib": {
+		"node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
-		"tsutils": {
+		"node_modules/tsutils": {
 			"version": "3.21.0",
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
 			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"tslib": "^1.8.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
 			}
 		},
-		"type-check": {
+		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"type-fest": {
+		"node_modules/type-fest": {
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
-		"typescript": {
+		"node_modules/typescript": {
 			"version": "4.6.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
 			"integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
 		},
-		"uri-js": {
+		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"punycode": "^2.1.0"
 			}
 		},
-		"uuid": {
+		"node_modules/uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
 		},
-		"v8-compile-cache": {
+		"node_modules/v8-compile-cache": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"vscode-dts": {
+		"node_modules/vscode-dts": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/vscode-dts/-/vscode-dts-0.3.3.tgz",
 			"integrity": "sha512-JfOsWL0NvfVw0UF9bcTjlv1Onz3Ted7cgpPWKWMnHGB+72t/tn8WFDeKLZO42l2k9KJq/NGS9rFC5gZbyI4FTg==",
+			"deprecated": "vscode-dts has been renamed to @vscode/dts. Install using @vscode/dts instead.",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"minimist": "^1.2.0",
 				"prompts": "^2.1.0",
 				"rimraf": "^3.0.0"
+			},
+			"bin": {
+				"vscode-dts": "index.js"
 			}
 		},
-		"webidl-conversions": {
+		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
 			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
 		},
-		"whatwg-url": {
+		"node_modules/whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-			"requires": {
+			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
 			}
 		},
-		"which": {
+		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
-			"requires": {
+			"dependencies": {
 				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
-		"word-wrap": {
+		"node_modules/word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"wrappy": {
+		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
 		},
-		"yallist": {
+		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",

--- a/code4me-vsc-plugin/package.json
+++ b/code4me-vsc-plugin/package.json
@@ -32,10 +32,6 @@
 	"contributes": {
 		"commands": [
 			{
-				"command": "code4me.helloWorld",
-				"title": "Hello World" 
-			}, 
-			{
 				"command": "code4me.action.triggerSuggest",
 				"title": "Trigger Suggest (code4me)"
 			}

--- a/code4me-vsc-plugin/package.json
+++ b/code4me-vsc-plugin/package.json
@@ -4,7 +4,7 @@
 	"description": "Language model code completion.",
 	"author": "Code4Me",
 	"license": "Apache-2.0",
-	"version": "1.0.9",
+	"version": "1.0.10",
 	"categories": [
 		"Machine Learning",
 		"Programming Languages",

--- a/code4me-vsc-plugin/package.json
+++ b/code4me-vsc-plugin/package.json
@@ -34,6 +34,18 @@
 			{
 				"command": "code4me.helloWorld",
 				"title": "Hello World" 
+			}, 
+			{
+				"command": "code4me.action.triggerSuggest",
+				"title": "Trigger Suggest (code4me)"
+			}
+		],
+		"keybindings": [
+			{
+				"command": "code4me.action.triggerSuggest",
+				"key": "ctrl+space",
+				"mac": "ctrl+space",
+				"when": "editorTextFocus && !suggestWidgetVisible"
 			}
 		],
 		"configuration": {

--- a/code4me-vsc-plugin/package.json
+++ b/code4me-vsc-plugin/package.json
@@ -26,10 +26,16 @@
 		"vscode": "^1.47.0"
 	},
 	"activationEvents": [
-		"*"
+		"onStartupFinished"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
+		"commands": [
+			{
+				"command": "code4me.helloWorld",
+				"title": "Hello World" 
+			}
+		],
 		"configuration": {
 			"title": "Code4Me",
 			"properties": {

--- a/code4me-vsc-plugin/src/extension.ts
+++ b/code4me-vsc-plugin/src/extension.ts
@@ -34,12 +34,12 @@ const AVG_TOKEN_LENGTH_IN_CHARS = 7984;
 const CODE4ME_EXTENSION_ID = 'Code4Me.code4me-plugin';
 const CODE4ME_VERSION = vscode.extensions.getExtension(CODE4ME_EXTENSION_ID)?.packageJSON['version']
 
-// TODO: (revert) for testing purposes
-const AUTOCOMPLETE_URL = 'http://127.0.0.1:3000/api/v2/prediction/autocomplete'
-const VERIFY_URL = 'http://127.0.0.1:3000/api/v2/prediction/verify'
+// // TODO: (revert) for testing purposes
+// const AUTOCOMPLETE_URL = 'http://127.0.0.1:3000/api/v2/prediction/autocomplete'
+// const VERIFY_URL = 'http://127.0.0.1:3000/api/v2/prediction/verify'
 
-// const AUTOCOMPLETE_URL = 'https://code4me.me/api/v2/prediction/autocomplete'
-// const VERIFY_URL = 'https://code4me.me/api/v2/prediction/autocomplete'
+const AUTOCOMPLETE_URL = 'https://code4me.me/api/v2/prediction/autocomplete'
+const VERIFY_URL = 'https://code4me.me/api/v2/prediction/autocomplete'
 
 const allowedTriggerCharacters = [' ', '.', '+', '-', '*', '/', '%', '<', '>', '**', '<<', '>>', '&', '|', '^', '+=', '-=', '==', '!=', ';', ',', '[', '(', '{', '~', '=', '<=', '>='];
 const allowedTriggerWords = ['await', 'assert', 'raise', 'del', 'lambda', 'yield', 'return', 'while', 'for', 'if', 'elif', 'else', 'global', 'in', 'and', 'not', 'or', 'is', 'with', 'except'];
@@ -84,7 +84,8 @@ async function start(context: vscode.ExtensionContext) {
   async function setupCompletions(): Promise<void> {
 
     let config = vscode.workspace.getConfiguration('code4me')
-    if (config.get('promptDataStorage')) { doPromptDataStorageMenu(config) }
+    // TODO: Revert this after the user-study 
+    // if (config.get('promptDataStorage')) { doPromptDataStorageMenu(config) }
 
     if (completionItemProvider !== null) {
       console.log('existing code4me completion provider found, resetting')

--- a/code4me-vsc-plugin/src/extension.ts
+++ b/code4me-vsc-plugin/src/extension.ts
@@ -1,17 +1,20 @@
 import * as vscode from 'vscode';
-import { ExtensionContext } from 'vscode';
 import rand from 'csprng';
 import fetch from 'node-fetch';
 import * as path from 'path';
 
+const DATA_STORAGE_WINDOW_REQUEST_TEXT = `
+Code4Me exists for research purposes – we'd like to 
+study the code context around completions. The data 
+is stored anonymously and removed after 3 months. `
+const DATA_STORAGE_OPT_IN     = "Agree";
+const DATA_STORAGE_REMIND_ME  = "Remind Me";
+const DATA_STORAGE_OPT_OUT    = "Opt Out";
+const DATA_STORAGE_READ_MORE  = "Read more";
+
 const INFORMATION_WINDOW_CLOSE = "Close";
 const MAX_REQUEST_WINDOW_CLOSE_1_HOUR = "Close for 1 hour";
 const INFORMATION_WINDOW_DONT_SHOW_AGAIN = "Don't show again";
-const DATA_STORAGE_WINDOW_REQUEST_TEXT = "To perform a failure analysis & improve code4me, we'd like to store the close context around completions. This data'll be stored anonymously & removed after 3 months. Would you like to participate in our study? We deeply appreciate your contribution.";
-const DATA_STORAGE_OPT_IN = "Yes";
-const DATA_STORAGE_REMIND_ME = "Remind Me";
-const DATA_STORAGE_OPT_OUT = "No";
-const DATA_STORAGE_READ_MORE = "Read more";
 const SURVEY_WINDOW_REQUEST_TEXT = "Do you mind filling in a quick survey about Code4Me?";
 const SURVEY_WINDOW_SURVEY = "Survey";
 
@@ -22,279 +25,404 @@ const CODE4ME_EXTENSION_ID = 'Code4Me.code4me-plugin';
 const allowedTriggerCharacters = ['.', '+', '-', '*', '/', '%', '<', '>', '**', '<<', '>>', '&', '|', '^', '+=', '-=', '==', '!=', ';', ',', '[', '(', '{', '~', '=', '<=', '>='];
 const allowedTriggerWords = ['await', 'assert', 'raise', 'del', 'lambda', 'yield', 'return', 'while', 'for', 'if', 'elif', 'else', 'global', 'in', 'and', 'not', 'or', 'is', 'with', 'except'];
 
-const configuration = vscode.workspace.getConfiguration('code4me', undefined);
-let promptMaxRequestWindow = true;
+// const configuration = vscode.workspace.getConfiguration('code4me', undefined);
+// let promptMaxRequestWindow = true;
 
-export function activate(extensionContext: ExtensionContext) {
-  if (!extensionContext.globalState.get('code4me-uuid')) {
-    extensionContext.globalState.update('code4me-uuid', rand(128, 16));
+
+export function activate(context: vscode.ExtensionContext) {
+
+  if (!context.globalState.get('code4me-uuid')) {
+    context.globalState.update('code4me-uuid', rand(128, 16));
   }
 
-  if (configuration.get('promptDataStorage')) doPromptDataStorageMenu();
-
-  const code4MeUuid: string = extensionContext.globalState.get('code4me-uuid')!;
-
-  extensionContext.subscriptions.push(vscode.commands.registerCommand('verifyInsertion', verifyInsertion));
-  extensionContext.subscriptions.push(vscode.languages.registerCompletionItemProvider({ pattern: '**' }, {
-    async provideCompletionItems(document, position, token, context) {
-      const jsonResponse = await callToAPIAndRetrieve(document, position, code4MeUuid, context.triggerKind);
-      if (!jsonResponse) return undefined;
-
-      const listPredictionItems = jsonResponse.predictions;
-
-      if (listPredictionItems.length == 0) return undefined;
-      const completionToken = jsonResponse.verifyToken;
-
-      const promptSurvey = configuration.get("code4me.promptSurvey");
-      if (jsonResponse.survey && promptSurvey) doPromptSurvey(code4MeUuid);
-
-
-      const timer = verifyInsertion(position, null, completionToken, code4MeUuid, null);
-      return listPredictionItems.map((prediction: string) => {
-        const completionItem = new vscode.CompletionItem('\u276E\uff0f\u276f: ' + prediction);
-        completionItem.sortText = '0.0000';
-        if (prediction == "") return undefined;
-        completionItem.insertText = prediction;
-
-        const positionFromCompletionToEndOfLine = new vscode.Position(position.line, document.lineAt(position.line).range.end.character);
-        const positionPlusOne = new vscode.Position(position.line, position.character + 1);
-        const charactersAfterCursor = document.getText(new vscode.Range(position, positionFromCompletionToEndOfLine));
-        const characterAfterCursor = charactersAfterCursor.charAt(0);
-
-        const lastTwoCharacterOfPrediction = prediction.slice(-2);
-        const lastCharacterOfPrediction = prediction.slice(-1);
-
-        if (lastTwoCharacterOfPrediction === '):' || lastTwoCharacterOfPrediction === ');' || lastTwoCharacterOfPrediction === '),') {
-          completionItem.range = new vscode.Range(position, positionFromCompletionToEndOfLine);
-        } else if (characterAfterCursor === lastCharacterOfPrediction) {
-          completionItem.range = new vscode.Range(position, positionPlusOne);
-        }
-
-        completionItem.command = {
-          command: 'verifyInsertion',
-          title: 'Verify Insertion',
-          arguments: [position, prediction, completionToken, code4MeUuid, timer]
-        };
-        return completionItem;
-      });
-    }
-  }, ' ', '.', '+', '-', '*', '/', '%', '*', '<', '>', '&', '|', '^', '=', '!', ';', ',', '[', '(', '{', '~'));
+  start(context).then(disposable => {
+    context.subscriptions.push(disposable);
+  })
+  console.log('Code4me Activated !')
 }
 
-function doPromptSurvey(code4MeUuid: string) {
-  vscode.window.showInformationMessage(
-    SURVEY_WINDOW_REQUEST_TEXT,
-    SURVEY_WINDOW_SURVEY,
-    INFORMATION_WINDOW_CLOSE,
-    INFORMATION_WINDOW_DONT_SHOW_AGAIN
-  ).then(selection => {
-    if (selection === SURVEY_WINDOW_SURVEY) {
-      const url = `https://code4me.me/api/v1/survey?user_id=${code4MeUuid}`;
-      vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+/** Create a new CompletionItemProvider on startup or when config changes */
+async function start(context: vscode.ExtensionContext) {
+
+  const disposables: vscode.Disposable[] = [];
+
+  let completionItemProvider : vscode.Disposable | null = null 
+  disposables.push({dispose: () => completionItemProvider?.dispose() })
+
+  async function setupCompletions(): Promise<void> {
+
+    let config = vscode.workspace.getConfiguration('code4me')
+    if (config.get('promptDataStorage')) { doPromptDataStorageMenu(config) }
+
+    if (completionItemProvider !== null) {
+      console.log('existing completion provider found, resetting')
+      completionItemProvider.dispose()
     }
-    if (selection === INFORMATION_WINDOW_DONT_SHOW_AGAIN) {
-      configuration.update('promptSurvey', false, true);
-    }
-  });
-}
-
-function doPromptDataStorageMenu() {
-  vscode.window.showInformationMessage(
-    DATA_STORAGE_WINDOW_REQUEST_TEXT,
-    DATA_STORAGE_OPT_IN,
-    DATA_STORAGE_REMIND_ME,
-    DATA_STORAGE_OPT_OUT,
-    DATA_STORAGE_READ_MORE
-  ).then(selection => {
-    const url = `https://code4me.me/`;
-
-    switch (selection) {
-      case DATA_STORAGE_OPT_IN:
-        configuration.update('storeContext', true, true);
-        configuration.update('promptDataStorage', false, true);
-        break;
-      case DATA_STORAGE_OPT_OUT:
-        configuration.update('promptDataStorage', false, true);
-        break;
-      case DATA_STORAGE_READ_MORE:
-        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
-        vscode.commands.executeCommand("workbench.action.openSettings", "code4me.storeContext");
-        configuration.update('promptDataStorage', false, true);
-        break;
-      default:
-        break;
-    }
-  });
-}
-
-function showMaxRequestWindow(displayedText: string) {
-  if (!promptMaxRequestWindow) return;
-  vscode.window.showInformationMessage(
-    displayedText,
-    INFORMATION_WINDOW_CLOSE,
-    MAX_REQUEST_WINDOW_CLOSE_1_HOUR,
-    INFORMATION_WINDOW_DONT_SHOW_AGAIN
-  ).then(selection => {
-    if (selection === MAX_REQUEST_WINDOW_CLOSE_1_HOUR) {
-      promptMaxRequestWindow = false;
-      setTimeout(() => {
-        promptMaxRequestWindow = true;
-      }, 3600 * 1000);
-    }
-    if (selection === INFORMATION_WINDOW_DONT_SHOW_AGAIN) {
-      promptMaxRequestWindow = false;
-    }
-  });
-}
-
-function showErrorWindow(text: string) {
-  vscode.window.showInformationMessage(text);
-}
-
-function getTriggerCharacter(document: vscode.TextDocument, position: vscode.Position, length: number) {
-  const endPos = new vscode.Position(position.line, position.character);
-  if (position.character - length < 0) return undefined;
-  const startCharacterPos = new vscode.Position(position.line, position.character - length);
-  const rangeCharacter = new vscode.Range(startCharacterPos, endPos);
-  const character = document.getText(rangeCharacter);
-  return character.trim();
-}
-
-/**
- * Returns the trigger character used for the completion.
- * @param document the document the completion was triggered.
- * @param position the current position of the cursor.
- * @returns triggerCharacter string or null (manual trigger suggest) or undefined if no trigger character was found.
- */
-function determineTriggerCharacter(document: vscode.TextDocument, position: vscode.Position, triggerKind: vscode.CompletionTriggerKind): string | null | undefined {
-  const singleTriggerCharacter = getTriggerCharacter(document, position, 1);
-  const doubleTriggerCharacter = getTriggerCharacter(document, position, 2);
-  const tripleTriggerCharacter = getTriggerCharacter(document, position, 3);
-
-  const startPosLine = new vscode.Position(position.line, 0);
-  const endPosLine = new vscode.Position(position.line, position.character);
-  const rangeLine = new vscode.Range(startPosLine, endPosLine);
-
-  const lineSplit = document.getText(rangeLine).trim().split(/[ ]+/g);
-  const lastWord = lineSplit != null ? lineSplit.pop()!.trim() : "";
-
-  // There are 3 kinds of triggers: Invoke = 0, triggerCharacter = 1, IncompleteItems = 2.
-  // Invoke always triggers on 24/7 completion (any character typed at start of word) and
-  // whenever there is a manual call to triggerSuggest. By cancelling out the 24/7 completion
-  // for Code4Me, we can detect a manual trigger.
-  if (triggerKind === vscode.CompletionTriggerKind.Invoke) {
-    // Manual completion on empty line.
-    if (lastWord.length === 0) return null;
-    // Likely start of word and triggered on 24/7 completion, do not autocomplete.
-    else if (lastWord.length === 1 && lastWord.match(/[A-z]+/g)) return undefined;
-    // Likely start of word and triggered on trigger characters, return trigger character as if trigger completion.
-    else if (lastWord.slice(lastWord.length - 1).match(/[^A-z]+/g)) return determineTriggerCharacter(document, position, vscode.CompletionTriggerKind.TriggerCharacter);
-    // Return found trigger word.
-    else return lastWord;
-  } else { // TriggerKind = 1, trigger completion
-    if (allowedTriggerWords.includes(lastWord)) return lastWord;
-    else if (tripleTriggerCharacter && allowedTriggerCharacters.includes(tripleTriggerCharacter)) return tripleTriggerCharacter;
-    else if (doubleTriggerCharacter && allowedTriggerCharacters.includes(doubleTriggerCharacter)) return doubleTriggerCharacter;
-    else if (singleTriggerCharacter && allowedTriggerCharacters.includes(singleTriggerCharacter)) return singleTriggerCharacter;
-    else return undefined;
+    completionItemProvider = await createCompletionItemProvider(context, config)
+    console.log('autocomplete enabled')
   }
+  setupCompletions() 
+
+  disposables.push(
+    vscode.workspace.onDidChangeConfiguration(e => {
+      if (e.affectsConfiguration('code4me')) { setupCompletions() }
+    }), 
+    vscode.commands.registerCommand('code4me.helloWorld', () => {
+      vscode.window.showInformationMessage('Hello from Code4Me!')
+    })
+  );
+
+  return vscode.Disposable.from(...disposables)
 }
 
-/**
- * 
- * @param nCharacters the amount of characters taken left and right of the cursor.
- * @param position the cursor position.
- * @returns an array with index 0 the left text and index 1 the right text. Empty strings if text editor cannot be found.
- */
-function splitTextAtCursor(nCharacters: number, position: vscode.Position): string[] {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor) return ['', ''];
-  const document = editor.document;
-  const documentLineCount = document.lineCount - 1;
-  const lastLine = document.lineAt(documentLineCount);
-  const beginDocumentPosition = new vscode.Position(0, 0);
-  const leftRange = new vscode.Range(beginDocumentPosition, position);
+async function createCompletionItemProvider(
+  context: vscode.ExtensionContext, 
+  config: vscode.WorkspaceConfiguration
+): Promise<vscode.Disposable> {
 
-  const lastLineCharacterOffset = lastLine.range.end.character;
-  const lastLineLineOffset = lastLine.lineNumber;
-  const endDocumentPosition = new vscode.Position(lastLineLineOffset, lastLineCharacterOffset);
-  const rightRange = new vscode.Range(position, endDocumentPosition);
+  const disposables: vscode.Disposable[] = [] 
+  // TODO: create an async function to retrieve language-specific settings. 
+  const languageFilters = { pattern: '**' }
+  const uuid : string = context.globalState.get('code4me-uuid')!;
 
-  const leftText = editor.document.getText(leftRange);
-  const rightText = editor.document.getText(rightRange);
+  disposables.push(
+    vscode.languages.registerCompletionItemProvider(
+      languageFilters, new CompletionItemProvider(uuid, config), ...allowedTriggerCharacters
+    )
+  )
 
-  return [leftText.substring(-nCharacters), rightText.substring(0, nCharacters)];
+  return { dispose: () => { disposables.forEach(d => d.dispose()) } }
 }
 
-async function callToAPIAndRetrieve(document: vscode.TextDocument, position: vscode.Position, code4MeUuid: string, triggerKind: vscode.CompletionTriggerKind): Promise<any | undefined> {
-  const textArray = splitTextAtCursor(AVERAGE_TOKEN_LENGHT_IN_CHARACTERS, position);
-  const triggerPoint = determineTriggerCharacter(document, position, triggerKind);
-  if (triggerPoint === undefined) return undefined;
-  const textLeft = textArray[0];
-  const textRight = textArray[1];
 
-  const configuration = vscode.workspace.getConfiguration('code4me', undefined);
+// // NOTE: this is straight up wrong, leads to an undisposable extension. 
+// // I don't know how this even got accepted into the VSC marketplace. 
+
+// export function activate(extensionContext: ExtensionContext) {
+//   if (!extensionContext.globalState.get('code4me-uuid')) {
+//     extensionContext.globalState.update('code4me-uuid', rand(128, 16));
+//   }
+
+//   if (configuration.get('promptDataStorage')) doPromptDataStorageMenu();
+
+//   const code4MeUuid: string = extensionContext.globalState.get('code4me-uuid')!;
+
+//   extensionContext.subscriptions.push(vscode.commands.registerCommand('verifyInsertion', verifyInsertion));
+//   extensionContext.subscriptions.push(
+//     vscode.languages.registerCompletionItemProvider({ pattern: '**' }, 
+//     {
+//       async provideCompletionItems(document, position, token, context) {
+//         const jsonResponse = await callToAPIAndRetrieve(document, position, code4MeUuid, context.triggerKind);
+//         if (!jsonResponse) return undefined;
+
+//         const listPredictionItems = jsonResponse.predictions;
+
+//         if (listPredictionItems.length == 0) return undefined;
+//         const completionToken = jsonResponse.verifyToken;
+
+//         const promptSurvey = configuration.get("code4me.promptSurvey");
+//         if (jsonResponse.survey && promptSurvey) doPromptSurvey(code4MeUuid);
+
+
+//         const timer = verifyInsertion(position, null, completionToken, code4MeUuid, null);
+//         return listPredictionItems.map((prediction: string) => {
+//           const completionItem = new vscode.CompletionItem('\u276E\uff0f\u276f: ' + prediction);
+//           completionItem.sortText = '0.0000';
+//           if (prediction == "") return undefined;
+//           completionItem.insertText = prediction;
+
+//           const positionFromCompletionToEndOfLine = new vscode.Position(position.line, document.lineAt(position.line).range.end.character);
+//           const positionPlusOne = new vscode.Position(position.line, position.character + 1);
+//           const charactersAfterCursor = document.getText(new vscode.Range(position, positionFromCompletionToEndOfLine));
+//           const characterAfterCursor = charactersAfterCursor.charAt(0);
+
+//           const lastTwoCharacterOfPrediction = prediction.slice(-2);
+//           const lastCharacterOfPrediction = prediction.slice(-1);
+
+//           if (lastTwoCharacterOfPrediction === '):' || lastTwoCharacterOfPrediction === ');' || lastTwoCharacterOfPrediction === '),') {
+//             completionItem.range = new vscode.Range(position, positionFromCompletionToEndOfLine);
+//           } else if (characterAfterCursor === lastCharacterOfPrediction) {
+//             completionItem.range = new vscode.Range(position, positionPlusOne);
+//           }
+
+//           completionItem.command = {
+//             command: 'verifyInsertion',
+//             title: 'Verify Insertion',
+//             arguments: [position, prediction, completionToken, code4MeUuid, timer]
+//           };
+//           return completionItem;
+//         });
+//       }
+//     }, 
+//     ' ', '.', '+', '-', '*', '/', '%', '*', '<', '>', '&', '|', '^', '=', '!', ';', ',', '[', '(', '{', '~')
+//   );
+//   extensionContext.subscriptions.push(
+//     vscode.languages.registerCompletionItemProvider({ language: '*' }, 
+//     new InlineCompletionItemProvider(), 
+//     ' ', '.', '+', '-', '*', '/', '%', '*', '<', '>', '&', '|', '^', '=', '!', ';', ',', '[', '(', '{', '~')
+//   );
+// }
+
+
+
+// function showMaxRequestWindow(displayedText: string) {
+//   if (!promptMaxRequestWindow) return;
+//   vscode.window.showInformationMessage(
+//     displayedText,
+//     INFORMATION_WINDOW_CLOSE,
+//     MAX_REQUEST_WINDOW_CLOSE_1_HOUR,
+//     INFORMATION_WINDOW_DONT_SHOW_AGAIN
+//   ).then(selection => {
+//     if (selection === MAX_REQUEST_WINDOW_CLOSE_1_HOUR) {
+//       promptMaxRequestWindow = false;
+//       setTimeout(() => {
+//         promptMaxRequestWindow = true;
+//       }, 3600 * 1000);
+//     }
+//     if (selection === INFORMATION_WINDOW_DONT_SHOW_AGAIN) {
+//       promptMaxRequestWindow = false;
+//     }
+//   });
+// }
+
+// function showErrorWindow(text: string) {
+//   vscode.window.showInformationMessage(text);
+// }
+
+// function getTriggerCharacter(document: vscode.TextDocument, position: vscode.Position, length: number) {
+//   const endPos = new vscode.Position(position.line, position.character);
+//   if (position.character - length < 0) return undefined;
+//   const startCharacterPos = new vscode.Position(position.line, position.character - length);
+//   const rangeCharacter = new vscode.Range(startCharacterPos, endPos);
+//   const character = document.getText(rangeCharacter);
+//   return character.trim();
+// }
+
+// /**
+//  * Returns the trigger character used for the completion.
+//  * @param document the document the completion was triggered.
+//  * @param position the current position of the cursor.
+//  * @returns triggerCharacter string or null (manual trigger suggest) or undefined if no trigger character was found.
+//  */
+// function determineTriggerCharacter(document: vscode.TextDocument, position: vscode.Position, triggerKind: vscode.CompletionTriggerKind): string | null | undefined {
+//   const singleTriggerCharacter = getTriggerCharacter(document, position, 1);
+//   const doubleTriggerCharacter = getTriggerCharacter(document, position, 2);
+//   const tripleTriggerCharacter = getTriggerCharacter(document, position, 3);
+
+//   const startPosLine = new vscode.Position(position.line, 0);
+//   const endPosLine = new vscode.Position(position.line, position.character);
+//   const rangeLine = new vscode.Range(startPosLine, endPosLine);
+
+//   const lineSplit = document.getText(rangeLine).trim().split(/[ ]+/g);
+//   const lastWord = lineSplit != null ? lineSplit.pop()!.trim() : "";
+
+//   // There are 3 kinds of triggers: Invoke = 0, triggerCharacter = 1, IncompleteItems = 2.
+//   // Invoke always triggers on 24/7 completion (any character typed at start of word) and
+//   // whenever there is a manual call to triggerSuggest. By cancelling out the 24/7 completion
+//   // for Code4Me, we can detect a manual trigger.
+//   if (triggerKind === vscode.CompletionTriggerKind.Invoke) {
+//     // Manual completion on empty line.
+//     if (lastWord.length === 0) return null;
+//     // Likely start of word and triggered on 24/7 completion, do not autocomplete.
+//     else if (lastWord.length === 1 && lastWord.match(/[A-z]+/g)) return undefined;
+//     // Likely start of word and triggered on trigger characters, return trigger character as if trigger completion.
+//     else if (lastWord.slice(lastWord.length - 1).match(/[^A-z]+/g)) return determineTriggerCharacter(document, position, vscode.CompletionTriggerKind.TriggerCharacter);
+//     // Return found trigger word.
+//     else return lastWord;
+//   } else { // TriggerKind = 1, trigger completion
+//     if (allowedTriggerWords.includes(lastWord)) return lastWord;
+//     else if (tripleTriggerCharacter && allowedTriggerCharacters.includes(tripleTriggerCharacter)) return tripleTriggerCharacter;
+//     else if (doubleTriggerCharacter && allowedTriggerCharacters.includes(doubleTriggerCharacter)) return doubleTriggerCharacter;
+//     else if (singleTriggerCharacter && allowedTriggerCharacters.includes(singleTriggerCharacter)) return singleTriggerCharacter;
+//     else return undefined;
+//   }
+// }
+
+// /**
+//  * 
+//  * @param nCharacters the amount of characters taken left and right of the cursor.
+//  * @param position the cursor position.
+//  * @returns an array with index 0 the left text and index 1 the right text. Empty strings if text editor cannot be found.
+//  */
+// function splitTextAtCursor(nCharacters: number, position: vscode.Position): string[] {
+//   const editor = vscode.window.activeTextEditor;
+//   if (!editor) return ['', ''];
+//   const document = editor.document;
+//   const documentLineCount = document.lineCount - 1;
+//   const lastLine = document.lineAt(documentLineCount);
+//   const beginDocumentPosition = new vscode.Position(0, 0);
+//   const leftRange = new vscode.Range(beginDocumentPosition, position);
+
+//   const lastLineCharacterOffset = lastLine.range.end.character;
+//   const lastLineLineOffset = lastLine.lineNumber;
+//   const endDocumentPosition = new vscode.Position(lastLineLineOffset, lastLineCharacterOffset);
+//   const rightRange = new vscode.Range(position, endDocumentPosition);
+
+//   const leftText = editor.document.getText(leftRange);
+//   const rightText = editor.document.getText(rightRange);
+
+//   return [leftText.substring(-nCharacters), rightText.substring(0, nCharacters)];
+// }
+
+// async function callToAPIAndRetrieve(document: vscode.TextDocument, position: vscode.Position, code4MeUuid: string, triggerKind: vscode.CompletionTriggerKind): Promise<any | undefined> {
+//   const textArray = splitTextAtCursor(AVERAGE_TOKEN_LENGHT_IN_CHARACTERS, position);
+//   const triggerPoint = determineTriggerCharacter(document, position, triggerKind);
+//   if (triggerPoint === undefined) return undefined;
+//   const textLeft = textArray[0];
+//   const textRight = textArray[1];
+
+//   const configuration = vscode.workspace.getConfiguration('code4me', undefined);
   
-  try {
-    const url = "https://code4me.me/api/v1/prediction/autocomplete";
-    const response = await fetch(url, {
-      method: "POST",
-      body: JSON.stringify(
-        {
-          "leftContext": textLeft,
-          "rightContext": textRight,
-          "triggerPoint": triggerPoint,
-          "language": document.fileName.split('.').pop(),
-          "ide": "vsc",
-          "keybind": triggerKind === vscode.CompletionTriggerKind.Invoke,
-          "pluginVersion": vscode.extensions.getExtension(CODE4ME_EXTENSION_ID)?.packageJSON['version'],
-          "storeContext": configuration.get('storeContext')
-        }
-      ),
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + code4MeUuid
-      }
-    });
+//   try {
+//     const url = "https://code4me.me/api/v1/prediction/autocomplete";
+//     const response = await fetch(url, {
+//       method: "POST",
+//       body: JSON.stringify(
+//         {
+//           "leftContext": textLeft,
+//           "rightContext": textRight,
+//           "triggerPoint": triggerPoint,
+//           "language": document.fileName.split('.').pop(),
+//           "ide": "vsc",
+//           "keybind": triggerKind === vscode.CompletionTriggerKind.Invoke,
+//           "pluginVersion": vscode.extensions.getExtension(CODE4ME_EXTENSION_ID)?.packageJSON['version'],
+//           "storeContext": configuration.get('storeContext')
+//         }
+//       ),
+//       headers: {
+//         'Content-Type': 'application/json',
+//         'Authorization': 'Bearer ' + code4MeUuid
+//       }
+//     });
 
-    if (!response.ok) {
-      if (response.status == 429) {
-        showMaxRequestWindow("You have exceeded the limit of 1000 suggestions per hour.");
-      }
-      console.error("Response status not OK! Status: ", response.status);
-      return undefined;
-    }
+//     if (!response.ok) {
+//       if (response.status == 429) {
+//         showMaxRequestWindow("You have exceeded the limit of 1000 suggestions per hour.");
+//       }
+//       console.error("Response status not OK! Status: ", response.status);
+//       return undefined;
+//     }
 
-    const contentType = response.headers.get('content-type');
-    if (!contentType || !contentType.includes('application/json')) {
-      console.error("Wrong content type!");
-      return undefined;
-    }
+//     const contentType = response.headers.get('content-type');
+//     if (!contentType || !contentType.includes('application/json')) {
+//       console.error("Wrong content type!");
+//       return undefined;
+//     }
 
-    const json = await response.json();
+//     const json = await response.json();
 
-    if (!Object.prototype.hasOwnProperty.call(json, 'predictions')) {
-      console.error("Predictions field not found in response!");
-      return undefined;
+//     if (!Object.prototype.hasOwnProperty.call(json, 'predictions')) {
+//       console.error("Predictions field not found in response!");
+//       return undefined;
+//     }
+//     if (!Object.prototype.hasOwnProperty.call(json, 'verifyToken')) {
+//       console.error("VerifyToken field not found in response!");
+//       return undefined;
+//     }
+//     if (!Object.prototype.hasOwnProperty.call(json, 'survey')) {
+//       console.error("Survey field not found in response!");
+//       return undefined;
+//     }
+//     return json;
+//   } catch (e) {
+//     console.error("Unexpected error: ", e);
+//     showErrorWindow("Unexpected error: " + e);
+//     return undefined;
+//   }
+// }
+
+// // eslint-disable-next-line @typescript-eslint/no-empty-function
+// export function deactivate() { }
+
+
+// NOTE: Class used in user study to provide inline completion items. 
+class CompletionItemProvider implements vscode.CompletionItemProvider {
+
+  constructor(private uuid: string, private config: vscode.WorkspaceConfiguration) {}
+
+  async callCompletionsAPI(document: vscode.TextDocument, position: vscode.Position, triggerKind: vscode.CompletionTriggerKind) {
+    const response: JSON = JSON 
+    // return response.predictions || []
+    // Replace list below with json attribute
+    let predictions: Array<string> = ['pred_new', 'pred_new_2', 'pred_old'] || []
+    // Now we either HAVE a list of completions, or undefined/null maps to empty list
+    predictions = predictions.filter((prediction: string) => prediction !== "");
+
+    return {
+      predictions: predictions || [],
+      verifyToken: 'token' || null,
+      survey: true || false
     }
-    if (!Object.prototype.hasOwnProperty.call(json, 'verifyToken')) {
-      console.error("VerifyToken field not found in response!");
-      return undefined;
-    }
-    if (!Object.prototype.hasOwnProperty.call(json, 'survey')) {
-      console.error("Survey field not found in response!");
-      return undefined;
-    }
-    return json;
-  } catch (e) {
-    console.error("Unexpected error: ", e);
-    showErrorWindow("Unexpected error: " + e);
-    return undefined;
   }
+
+  async provideCompletionItems(
+    document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext
+  ): Promise<vscode.CompletionList | undefined>
+  {
+    const response = await this.callCompletionsAPI(document, position, context.triggerKind);
+    
+    if (response.predictions.length === 0) return undefined 
+
+    const promptSurvey = this.config.get("code4me.promptSurvey");
+    if (response.survey && promptSurvey) doPromptSurvey(this.uuid, this.config);
+
+    const completionToken: string = response.verifyToken;
+    const command: NodeJS.Timeout = verifyInsertion(position, null, completionToken, this.uuid, null);
+    const completionItems :vscode.CompletionItem[] = response.predictions.map((prediction: string) => {
+      return createCompletionItem(prediction, position, document, completionToken, this.uuid, command)
+    })
+
+    return new vscode.CompletionList(completionItems, false)
+  }
+
+  resolveCompletionItem?(item: vscode.CompletionItem, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CompletionItem> {
+    throw new Error('Method not implemented.');
+  }
+
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-export function deactivate() { }
+function createCompletionItem(
+  prediction: string, position: vscode.Position, document: vscode.TextDocument, 
+  completionToken: string, code4MeUuid: string, timer: NodeJS.Timeout | null
+): vscode.CompletionItem
+{
+  // We filter them out earlier in callCompletionsAPI, to have more type-safe logic 
+  // if (prediction == "") return undefined;
+
+  const item = new vscode.CompletionItem(
+    prediction, 
+    vscode.CompletionItemKind.EnumMember // I chose this because it's less common than 'Property' 
+  )
+  item.insertText = prediction  // No longer necessary as 'detail' now contains the logo
+  item.filterText = prediction  // The culprit of why suggestions were ranked at the bottom
+  item.sortText = '0' // Force sort at the top always (when compared with other identical prefixes)
+  item.detail = '\u276E\uff0f\u276f' // Logo 
+
+  // TODO: in the future, it could be nice to show to users which model generated 
+  // this suggestion. And, maybe even summarise with another LLM
+  item.documentation = 'Code4Me Completion' 
+
+  const positionFromCompletionToEndOfLine = new vscode.Position(position.line, document.lineAt(position.line).range.end.character);
+  const positionPlusOne = new vscode.Position(position.line, position.character + 1);
+  const charactersAfterCursor = document.getText(new vscode.Range(position, positionFromCompletionToEndOfLine));
+  const characterAfterCursor = charactersAfterCursor.charAt(0);
+
+  const lastTwoCharacterOfPrediction = prediction.slice(-2);
+  const lastCharacterOfPrediction = prediction.slice(-1);
+
+  if (lastTwoCharacterOfPrediction === '):' || lastTwoCharacterOfPrediction === ');' || lastTwoCharacterOfPrediction === '),') {
+    item.range = new vscode.Range(position, positionFromCompletionToEndOfLine);
+  } else if (characterAfterCursor === lastCharacterOfPrediction) {
+    item.range = new vscode.Range(position, positionPlusOne);
+  }
+
+  item.command = {
+    command: 'verifyInsertion',
+    title: 'Verify Insertion',
+    arguments: [position, prediction, completionToken, code4MeUuid, timer]
+  };
+  return item;
+}
 
 function verifyInsertion(position: vscode.Position, completion: string | null, completionToken: string, apiKey: string, timer: NodeJS.Timeout | null) {
   if (timer !== null) clearTimeout(timer);
@@ -367,4 +495,50 @@ function verifyInsertion(position: vscode.Position, completion: string | null, c
       return undefined;
     }
   }, 30000);
+}
+
+function doPromptDataStorageMenu(config: vscode.WorkspaceConfiguration) {
+  vscode.window.showInformationMessage(
+    DATA_STORAGE_WINDOW_REQUEST_TEXT,
+    DATA_STORAGE_OPT_IN,
+    DATA_STORAGE_REMIND_ME,
+    DATA_STORAGE_OPT_OUT,
+    DATA_STORAGE_READ_MORE
+  ).then(selection => {
+    const url = `https://code4me.me/`;
+
+    switch (selection) {
+      case DATA_STORAGE_OPT_IN:
+        config.update('storeContext', true, true);
+        config.update('promptDataStorage', false, true);
+        break;
+      case DATA_STORAGE_OPT_OUT:
+        config.update('promptDataStorage', false, true);
+        break;
+      case DATA_STORAGE_READ_MORE:
+        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+        vscode.commands.executeCommand("workbench.action.openSettings", "code4me.storeContext");
+        config.update('promptDataStorage', false, true);
+        break;
+      default:
+        break;
+    }
+  });
+}
+
+function doPromptSurvey(uuid: string, config: vscode.WorkspaceConfiguration) {
+  vscode.window.showInformationMessage(
+    SURVEY_WINDOW_REQUEST_TEXT,
+    SURVEY_WINDOW_SURVEY,
+    INFORMATION_WINDOW_CLOSE,
+    INFORMATION_WINDOW_DONT_SHOW_AGAIN
+  ).then(selection => {
+    if (selection === SURVEY_WINDOW_SURVEY) {
+      const url = `https://code4me.me/api/v1/survey?user_id=${uuid}`;
+      vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+    }
+    if (selection === INFORMATION_WINDOW_DONT_SHOW_AGAIN) {
+      config.update('promptSurvey', false, true);
+    }
+  });
 }

--- a/code4me-vsc-plugin/src/extension.ts
+++ b/code4me-vsc-plugin/src/extension.ts
@@ -18,15 +18,21 @@ const INFORMATION_WINDOW_DONT_SHOW_AGAIN = "Don't show again";
 const SURVEY_WINDOW_REQUEST_TEXT = "Do you mind filling in a quick survey about Code4Me?";
 const SURVEY_WINDOW_SURVEY = "Survey";
 
-const AVERAGE_TOKEN_LENGHT_IN_CHARACTERS = 7984;
+const AVG_TOKEN_LENGTH_IN_CHARS = 7984;
 
 const CODE4ME_EXTENSION_ID = 'Code4Me.code4me-plugin';
 
-const allowedTriggerCharacters = ['.', '+', '-', '*', '/', '%', '<', '>', '**', '<<', '>>', '&', '|', '^', '+=', '-=', '==', '!=', ';', ',', '[', '(', '{', '~', '=', '<=', '>='];
+// const allowedTriggerCharacters = ['.', '+', '-', '*', '/', '%', '<', '>', '**', '<<', '>>', '&', '|', '^', '+=', '-=', '==', '!=', ';', ',', '[', '(', '{', '~', '=', '<=', '>='];
+
+// const allowedTriggerCharacters = Array.from({length: 128}, (_, i) => String.fromCharCode(i));
+// The above, but only including visible characters 
+// const allowedTriggerCharacters = Array.from({length: 95}, (_, i) => String.fromCharCode(i + 32));
 const allowedTriggerWords = ['await', 'assert', 'raise', 'del', 'lambda', 'yield', 'return', 'while', 'for', 'if', 'elif', 'else', 'global', 'in', 'and', 'not', 'or', 'is', 'with', 'except'];
 
-// const configuration = vscode.workspace.getConfiguration('code4me', undefined);
-// let promptMaxRequestWindow = true;
+
+// NOTE: extremely bad practice to put state at the top here, as 
+// it is 1. not clear what it's for; 2. not disposed of properly when extension is deactivated
+let promptMaxRequestWindow = true;
 
 
 export function activate(context: vscode.ExtensionContext) {
@@ -37,9 +43,12 @@ export function activate(context: vscode.ExtensionContext) {
 
   start(context).then(disposable => {
     context.subscriptions.push(disposable);
+    console.log('Code4me Activated !')
   })
-  console.log('Code4me Activated !')
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export function deactivate() { }
 
 /** Create a new CompletionItemProvider on startup or when config changes */
 async function start(context: vscode.ExtensionContext) {
@@ -55,13 +64,17 @@ async function start(context: vscode.ExtensionContext) {
     if (config.get('promptDataStorage')) { doPromptDataStorageMenu(config) }
 
     if (completionItemProvider !== null) {
-      console.log('existing completion provider found, resetting')
+      console.log('existing code4me completion provider found, resetting')
       completionItemProvider.dispose()
     }
     completionItemProvider = await createCompletionItemProvider(context, config)
-    console.log('autocomplete enabled')
+    console.log('code4me completions enabled')
   }
   setupCompletions() 
+
+  // vscode.commands.getCommands(false).then(commands => {
+  //   console.log('commands: ', commands)
+  // })
 
   disposables.push(
     vscode.workspace.onDidChangeConfiguration(e => {
@@ -69,7 +82,25 @@ async function start(context: vscode.ExtensionContext) {
     }), 
     vscode.commands.registerCommand('code4me.helloWorld', () => {
       vscode.window.showInformationMessage('Hello from Code4Me!')
-    })
+    }),
+    // // vscode.commands.registerCommand('editor.action.triggerSuggest', () => {
+    // //   vscode.commands.executeCommand('vscode.executeCompletionItemProvider'),
+    // //   console.log('triggersuggest called!')
+    // // })
+    
+    // vscode.commands.registerCommand('editor.action.triggerSuggest', () => {
+
+    //   const editor = vscode.window.activeTextEditor
+    //   if (editor === undefined) return
+    //   const uri = editor.document.uri
+    //   const position = editor.selection.active
+    //   const triggerCharacter = null 
+    //   const itemResolveCount = undefined
+
+    //   vscode.commands.executeCommand('vscode.executeCompletionItemProvider', uri, position, triggerCharacter, itemResolveCount)
+    //   vscode.commands.executeCommand('editor.actions.triggerSuggest')
+    //   console.log('triggersuggest called!')
+    // })
   );
 
   return vscode.Disposable.from(...disposables)
@@ -81,13 +112,24 @@ async function createCompletionItemProvider(
 ): Promise<vscode.Disposable> {
 
   const disposables: vscode.Disposable[] = [] 
-  // TODO: create an async function to retrieve language-specific settings. 
+  // TODO: create an async function to retrieve language-specific settings, 
+  // and add to disposables. 
   const languageFilters = { pattern: '**' }
   const uuid : string = context.globalState.get('code4me-uuid')!;
+  const completionItemProvider = new CompletionItemProvider(uuid, config)
 
   disposables.push(
+    // This is the only way I could figure out how to check for manual triggers. 
+    // Override the keybind for vscode.actions.triggerSuggest (see package.json > keybinds)
+    // As a result, vscode triggerSuggest is not called (still exists in the command palette)
+    // Then, we can modify the completionItemProvider.manual property to true, 
+    // and then execute the built-in triggerSuggest command
+    vscode.commands.registerCommand('code4me.action.triggerSuggest', () => {
+      completionItemProvider.manual = true; 
+      vscode.commands.executeCommand('editor.action.triggerSuggest')
+    }),
     vscode.languages.registerCompletionItemProvider(
-      languageFilters, new CompletionItemProvider(uuid, config), ...allowedTriggerCharacters
+      languageFilters, completionItemProvider
     ), 
     vscode.commands.registerCommand('verifyInsertion', verifyInsertion)
   )
@@ -95,9 +137,424 @@ async function createCompletionItemProvider(
   return { dispose: () => { disposables.forEach(d => d.dispose()) } }
 }
 
+// NOTE: Class used in user study to provide inline completion items.
+// Honestly, I'm biased but would strongly consider using this instead 
+// of the previous code, as I fixed a few serious bugs  
 
-// // NOTE: this is straight up wrong, leads to an undisposable extension. 
-// // I don't know how this even got accepted into the VSC marketplace. 
+/** Completion Item Provider, impl 2 methods: 
+ * 1. provideCompletionItems: generates a list of completions
+ * 2. resolveCompletionItems: used in case the list is incomplete (i.e. lazy loading), not used here. 
+ * 
+ * Method 1 uses `callCompletionsAPI` to fetch completions from the server,
+ * and then maps the response to a list of `vscode.CompletionItem` objects.
+ */
+class CompletionItemProvider implements vscode.CompletionItemProvider {
+
+  manual: boolean = false
+  constructor(private uuid: string, private config: vscode.WorkspaceConfiguration) {}
+
+  async callCompletionsAPI(document: vscode.TextDocument, position: vscode.Position, triggerKind: vscode.CompletionTriggerKind) {
+    if (this.manual) {
+      console.log('manually called completions API')
+      this.manual = false 
+    } else {
+      console.log('automatically called completions API')
+    }
+    const response: JSON = JSON 
+    // return response.predictions || []
+    // Replace list below with json attribute
+    let predictions: Array<string> = ['pred_new', 'pred_new_2', 'pred_old'] || []
+    // Now we either HAVE a list of completions, or undefined/null maps to empty list
+    predictions = predictions.filter((prediction: string) => prediction !== "");
+
+    return {
+      predictions: predictions || [],
+      verifyToken: 'token' || null,
+      survey: true || false
+    }
+  }
+
+  async provideCompletionItems(
+    document: vscode.TextDocument, 
+    position: vscode.Position, 
+    token: vscode.CancellationToken, 
+    context: vscode.CompletionContext
+  ): Promise<vscode.CompletionList | undefined>
+  {
+    const response = await this.callCompletionsAPI(document, position, context.triggerKind);
+    
+    if (response.predictions.length === 0) return undefined 
+
+    const promptSurvey = this.config.get("code4me.promptSurvey");
+    if (response.survey && promptSurvey) doPromptSurvey(this.uuid, this.config);
+
+    const verifyToken: string = response.verifyToken;
+    const completionItems :vscode.CompletionItem[] = response.predictions.map((prediction: string) => {
+      return createCompletionItem(prediction, position, document, verifyToken, this.uuid)
+    })
+
+    return new vscode.CompletionList(completionItems, false)
+  }
+
+  resolveCompletionItem?(item: vscode.CompletionItem, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CompletionItem> {
+    throw new Error('Method not implemented.');
+  }
+
+}
+
+function createCompletionItem(
+  prediction: string, position: vscode.Position, document: vscode.TextDocument, 
+  verifyToken: string, uuid: string
+): vscode.CompletionItem
+{
+  const item = new vscode.CompletionItem(
+    prediction, 
+    vscode.CompletionItemKind.EnumMember // I chose this because it's less common than 'Property' 
+  )
+  item.insertText = prediction  // No longer necessary as 'detail' now contains the logo
+  item.filterText = prediction  // The culprit of why suggestions were ranked at the bottom
+  item.sortText = '0' // Force sort at the top always (when compared with other identical prefixes)
+  item.detail = '\u276E\uff0f\u276f' // Logo 
+
+  // TODO: in the future, it could be nice to show to users which model generated 
+  // this suggestion. And, maybe even summarise with another LLM
+  item.documentation = 'Code4Me Completion' 
+
+  const positionFromCompletionToEndOfLine = new vscode.Position(position.line, document.lineAt(position.line).range.end.character);
+  const positionPlusOne = new vscode.Position(position.line, position.character + 1);
+  const charactersAfterCursor = document.getText(new vscode.Range(position, positionFromCompletionToEndOfLine));
+  const characterAfterCursor = charactersAfterCursor.charAt(0);
+
+  const lastTwoCharacterOfPrediction = prediction.slice(-2);
+  const lastCharacterOfPrediction = prediction.slice(-1);
+
+  if (lastTwoCharacterOfPrediction === '):' || lastTwoCharacterOfPrediction === ');' || lastTwoCharacterOfPrediction === '),') {
+    item.range = new vscode.Range(position, positionFromCompletionToEndOfLine);
+  } else if (characterAfterCursor === lastCharacterOfPrediction) {
+    item.range = new vscode.Range(position, positionPlusOne);
+  }
+
+  item.command = {
+    command: 'verifyInsertion',
+    title: 'Verify Insertion',
+    arguments: [prediction, position, document, verifyToken, uuid]
+  };
+  return item;
+}
+
+/**
+ * Calls verification API after a 30s timeout with the completion and the ground truth.
+ * TODO: this implementation is incorrect. (also the lack of documentation does not help at all for tracking lines)
+ * MVE: call completion on line 3, then delete line 3. The resulting `lineNumber` is 1 somehow. 
+ * @param prediction prediction for which this callback is created
+ * @param position position of the completion
+ * @param document the prediction is in 
+ * @param verifyToken query UUID 
+ * @param uuid user UUID
+ * @returns 
+ */
+function verifyInsertion(
+  prediction: string, 
+  position: vscode.Position, 
+  document: vscode.TextDocument,
+  verifyToken: string,
+  uuid: string
+) {
+  console.log('verifyInsertion called for completion: ', prediction, ' at position: ', position, ' with token: ', verifyToken, ' and apiKey: ', uuid)
+  // if (timer !== null) clearTimeout(timer);
+  const documentName = document.fileName;
+  let lineNumber = position.line;
+  const originalOffset = position.character;
+  let characterOffset = originalOffset;
+
+  const listener = vscode.workspace.onDidChangeTextDocument(event => {
+    if (vscode.window.activeTextEditor == undefined) return;
+    if (vscode.window.activeTextEditor.document.fileName !== documentName) return;
+    for (const changes of event.contentChanges) {
+      const text = changes.text;
+      const startChangedLineNumber = changes.range.start.line;
+      const endChangedLineNumber = changes.range.end.line;
+
+      if (startChangedLineNumber == lineNumber - 1 && endChangedLineNumber == lineNumber && changes.text == '') {
+        lineNumber--;
+        const startLine = document.lineAt(startChangedLineNumber);
+        if (startLine.isEmptyOrWhitespace) characterOffset++;
+        else characterOffset += changes.range.start.character + 1;
+      }
+
+      if (startChangedLineNumber == lineNumber) {
+        if (changes.range.end.character < characterOffset + 1) {
+          if (changes.text === '') {
+            characterOffset -= changes.rangeLength;
+          } if (changes.text.includes('\n')) {
+            characterOffset = originalOffset;
+            lineNumber += (text.match(/\n/g) ?? []).length;
+          } else {
+            characterOffset += changes.text.length;
+          }
+        }
+      } else if (lineNumber == 0 || startChangedLineNumber < lineNumber) {
+        lineNumber += (text.match(/\n/g) ?? []).length;
+      }
+
+      if (changes.range.end.line <= lineNumber) {
+        if (changes.text === '') {
+          lineNumber -= changes.range.end.line - startChangedLineNumber;
+        }
+      }
+    }
+  });
+
+  return setTimeout(async () => {
+    listener.dispose();
+
+    // given that the document may have been modified and no longer contain lineNumber lines,
+    // set lineText to undefined if lineNumber is out of bounds
+    const groundTruth = lineNumber < document.lineCount ? 
+      document.lineAt(lineNumber).text?.substring(characterOffset).trim() : null;
+    
+    console.log('verifying with ground-truth: ', groundTruth, ' at lineText: ', ' and characterOffset: ', characterOffset, ' and lineNumber: ', lineNumber)
+    const response = await fetch("https://code4me.me/api/v1/prediction/verify", {
+      method: 'POST',
+      body: JSON.stringify(
+        {
+          "verifyToken": verifyToken,
+          "chosenPrediction": prediction,
+          "groundTruth": groundTruth, 
+        }
+      ),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + uuid
+      }
+    });
+
+    if (!response.ok) {
+      console.error("Response status not OK! Status: ", response.status);
+      return undefined;
+    }
+  }, 30000);
+}
+
+function showMaxRequestWindow(displayedText: string) {
+  if (!promptMaxRequestWindow) return;
+  vscode.window.showInformationMessage(
+    displayedText,
+    INFORMATION_WINDOW_CLOSE,
+    MAX_REQUEST_WINDOW_CLOSE_1_HOUR,
+    INFORMATION_WINDOW_DONT_SHOW_AGAIN
+  ).then(selection => {
+    if (selection === MAX_REQUEST_WINDOW_CLOSE_1_HOUR) {
+      promptMaxRequestWindow = false;
+      setTimeout(() => {
+        promptMaxRequestWindow = true;
+      }, 3600 * 1000);
+    }
+    if (selection === INFORMATION_WINDOW_DONT_SHOW_AGAIN) {
+      promptMaxRequestWindow = false;
+    }
+  });
+}
+
+function showErrorWindow(text: string) {
+  vscode.window.showInformationMessage(text);
+}
+
+function getTriggerCharacter(document: vscode.TextDocument, position: vscode.Position, length: number) {
+  const endPos = new vscode.Position(position.line, position.character);
+  if (position.character - length < 0) return undefined;
+  const startCharacterPos = new vscode.Position(position.line, position.character - length);
+  const rangeCharacter = new vscode.Range(startCharacterPos, endPos);
+  const character = document.getText(rangeCharacter);
+  return character.trim();
+}
+
+/**
+ * Returns the trigger character used for the completion.
+ * @param document the document the completion was triggered.
+ * @param position the current position of the cursor.
+ * @returns triggerCharacter string or null (manual trigger suggest) or undefined if no trigger character was found.
+ */
+function determineTriggerCharacter(document: vscode.TextDocument, position: vscode.Position, triggerKind: vscode.CompletionTriggerKind): string | null | undefined {
+  const singleTriggerCharacter = getTriggerCharacter(document, position, 1);
+  const doubleTriggerCharacter = getTriggerCharacter(document, position, 2);
+  const tripleTriggerCharacter = getTriggerCharacter(document, position, 3);
+
+  const startPosLine = new vscode.Position(position.line, 0);
+  const endPosLine = new vscode.Position(position.line, position.character);
+  const rangeLine = new vscode.Range(startPosLine, endPosLine);
+
+  const lineSplit = document.getText(rangeLine).trim().split(/[ ]+/g);
+  const lastWord = lineSplit != null ? lineSplit.pop()!.trim() : "";
+
+  // There are 3 kinds of triggers: Invoke = 0, triggerCharacter = 1, IncompleteItems = 2.
+  // Invoke always triggers on 24/7 completion (any character typed at start of word) and
+  // whenever there is a manual call to triggerSuggest. By cancelling out the 24/7 completion
+  // for Code4Me, we can detect a manual trigger.
+  if (triggerKind === vscode.CompletionTriggerKind.Invoke) {
+    // Manual completion on empty line.
+    if (lastWord.length === 0) return null;
+    // Likely start of word and triggered on 24/7 completion, do not autocomplete.
+    else if (lastWord.length === 1 && lastWord.match(/[A-z]+/g)) return undefined;
+    // Likely start of word and triggered on trigger characters, return trigger character as if trigger completion.
+    else if (lastWord.slice(lastWord.length - 1).match(/[^A-z]+/g)) return determineTriggerCharacter(document, position, vscode.CompletionTriggerKind.TriggerCharacter);
+    // Return found trigger word.
+    else return lastWord;
+  } else { // TriggerKind = 1, trigger completion
+    if (allowedTriggerWords.includes(lastWord)) return lastWord;
+    else if (tripleTriggerCharacter && allowedTriggerCharacters.includes(tripleTriggerCharacter)) return tripleTriggerCharacter;
+    else if (doubleTriggerCharacter && allowedTriggerCharacters.includes(doubleTriggerCharacter)) return doubleTriggerCharacter;
+    else if (singleTriggerCharacter && allowedTriggerCharacters.includes(singleTriggerCharacter)) return singleTriggerCharacter;
+    else return undefined;
+  }
+}
+
+/**
+ * Splits the current document on the cursor position, with AVG_TOKEN_LENGTH_IN_CHARS characters left and right of the cursor.
+ * @param document the current document.
+ * @param position the cursor position.
+ * @returns an array with index 0 the left text and index 1 the right text. Empty strings if text editor cannot be found.
+ */
+function splitTextAtCursor(
+  document: vscode.TextDocument, 
+  position: vscode.Position
+): string[] 
+{
+  // should not happen now that we directly pass document instead of relying on global state
+  // as a result, this function can only be called IFF there is a TextDocument
+  if (!document) return ['', ''] 
+
+  const documentLineCount = document.lineCount - 1
+  const lastLine = document.lineAt(documentLineCount)
+  const beginDocumentPosition = new vscode.Position(0, 0)
+  const leftRange = new vscode.Range(beginDocumentPosition, position)
+
+  const lastLineCharacterOffset = lastLine.range.end.character
+  const lastLineLineOffset = lastLine.lineNumber
+  const endDocumentPosition = new vscode.Position(lastLineLineOffset, lastLineCharacterOffset)
+  const rightRange = new vscode.Range(position, endDocumentPosition)
+
+  const leftText = document.getText(leftRange)
+  const rightText = document.getText(rightRange)
+
+  return [
+    leftText.substring(-AVG_TOKEN_LENGTH_IN_CHARS), 
+    rightText.substring(0, AVG_TOKEN_LENGTH_IN_CHARS)
+  ]
+}
+
+async function callToAPIAndRetrieve(document: vscode.TextDocument, position: vscode.Position, code4MeUuid: string, triggerKind: vscode.CompletionTriggerKind): Promise<any | undefined> {
+  const textArray = splitTextAtCursor(document, position);
+  const triggerPoint = determineTriggerCharacter(document, position, triggerKind);
+  if (triggerPoint === undefined) return undefined;
+  const textLeft = textArray[0];
+  const textRight = textArray[1];
+
+  const configuration = vscode.workspace.getConfiguration('code4me', undefined);
+  
+  try {
+    const url = "https://code4me.me/api/v1/prediction/autocomplete";
+    const response = await fetch(url, {
+      method: "POST",
+      body: JSON.stringify(
+        {
+          "leftContext": textLeft,
+          "rightContext": textRight,
+          "triggerPoint": triggerPoint,
+          "language": document.fileName.split('.').pop(),
+          "ide": "vsc",
+          "keybind": triggerKind === vscode.CompletionTriggerKind.Invoke,
+          "pluginVersion": vscode.extensions.getExtension(CODE4ME_EXTENSION_ID)?.packageJSON['version'],
+          "storeContext": configuration.get('storeContext')
+        }
+      ),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + code4MeUuid
+      }
+    });
+
+    if (!response.ok) {
+      if (response.status == 429) {
+        showMaxRequestWindow("You have exceeded the limit of 1000 suggestions per hour.");
+      }
+      console.error("Response status not OK! Status: ", response.status);
+      return undefined;
+    }
+
+    const contentType = response.headers.get('content-type');
+    if (!contentType || !contentType.includes('application/json')) {
+      console.error("Wrong content type!");
+      return undefined;
+    }
+
+    const json = await response.json();
+
+    if (!Object.prototype.hasOwnProperty.call(json, 'predictions')) {
+      console.error("Predictions field not found in response!");
+      return undefined;
+    }
+    if (!Object.prototype.hasOwnProperty.call(json, 'verifyToken')) {
+      console.error("VerifyToken field not found in response!");
+      return undefined;
+    }
+    if (!Object.prototype.hasOwnProperty.call(json, 'survey')) {
+      console.error("Survey field not found in response!");
+      return undefined;
+    }
+    return json;
+  } catch (e) {
+    console.error("Unexpected error: ", e);
+    showErrorWindow("Unexpected error: " + e);
+    return undefined;
+  }
+}
+
+function doPromptDataStorageMenu(config: vscode.WorkspaceConfiguration) {
+  vscode.window.showInformationMessage(
+    DATA_STORAGE_WINDOW_REQUEST_TEXT,
+    DATA_STORAGE_OPT_IN,
+    DATA_STORAGE_REMIND_ME,
+    DATA_STORAGE_OPT_OUT,
+    DATA_STORAGE_READ_MORE
+  ).then(selection => {
+    const url = `https://code4me.me/`;
+
+    switch (selection) {
+      case DATA_STORAGE_OPT_IN:
+        config.update('storeContext', true, true);
+        config.update('promptDataStorage', false, true);
+        break;
+      case DATA_STORAGE_OPT_OUT:
+        config.update('promptDataStorage', false, true);
+        break;
+      case DATA_STORAGE_READ_MORE:
+        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+        vscode.commands.executeCommand("workbench.action.openSettings", "code4me.storeContext");
+        config.update('promptDataStorage', false, true);
+        break;
+      default:
+        break;
+    }
+  });
+}
+
+function doPromptSurvey(uuid: string, config: vscode.WorkspaceConfiguration) {
+  vscode.window.showInformationMessage(
+    SURVEY_WINDOW_REQUEST_TEXT,
+    SURVEY_WINDOW_SURVEY,
+    INFORMATION_WINDOW_CLOSE,
+    INFORMATION_WINDOW_DONT_SHOW_AGAIN
+  ).then(selection => {
+    if (selection === SURVEY_WINDOW_SURVEY) {
+      const url = `https://code4me.me/api/v1/survey?user_id=${uuid}`;
+      vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+    }
+    if (selection === INFORMATION_WINDOW_DONT_SHOW_AGAIN) {
+      config.update('promptSurvey', false, true);
+    }
+  });
+}
 
 // export function activate(extensionContext: ExtensionContext) {
 //   if (!extensionContext.globalState.get('code4me-uuid')) {
@@ -163,382 +620,3 @@ async function createCompletionItemProvider(
 //     ' ', '.', '+', '-', '*', '/', '%', '*', '<', '>', '&', '|', '^', '=', '!', ';', ',', '[', '(', '{', '~')
 //   );
 // }
-
-
-
-// function showMaxRequestWindow(displayedText: string) {
-//   if (!promptMaxRequestWindow) return;
-//   vscode.window.showInformationMessage(
-//     displayedText,
-//     INFORMATION_WINDOW_CLOSE,
-//     MAX_REQUEST_WINDOW_CLOSE_1_HOUR,
-//     INFORMATION_WINDOW_DONT_SHOW_AGAIN
-//   ).then(selection => {
-//     if (selection === MAX_REQUEST_WINDOW_CLOSE_1_HOUR) {
-//       promptMaxRequestWindow = false;
-//       setTimeout(() => {
-//         promptMaxRequestWindow = true;
-//       }, 3600 * 1000);
-//     }
-//     if (selection === INFORMATION_WINDOW_DONT_SHOW_AGAIN) {
-//       promptMaxRequestWindow = false;
-//     }
-//   });
-// }
-
-// function showErrorWindow(text: string) {
-//   vscode.window.showInformationMessage(text);
-// }
-
-// function getTriggerCharacter(document: vscode.TextDocument, position: vscode.Position, length: number) {
-//   const endPos = new vscode.Position(position.line, position.character);
-//   if (position.character - length < 0) return undefined;
-//   const startCharacterPos = new vscode.Position(position.line, position.character - length);
-//   const rangeCharacter = new vscode.Range(startCharacterPos, endPos);
-//   const character = document.getText(rangeCharacter);
-//   return character.trim();
-// }
-
-// /**
-//  * Returns the trigger character used for the completion.
-//  * @param document the document the completion was triggered.
-//  * @param position the current position of the cursor.
-//  * @returns triggerCharacter string or null (manual trigger suggest) or undefined if no trigger character was found.
-//  */
-// function determineTriggerCharacter(document: vscode.TextDocument, position: vscode.Position, triggerKind: vscode.CompletionTriggerKind): string | null | undefined {
-//   const singleTriggerCharacter = getTriggerCharacter(document, position, 1);
-//   const doubleTriggerCharacter = getTriggerCharacter(document, position, 2);
-//   const tripleTriggerCharacter = getTriggerCharacter(document, position, 3);
-
-//   const startPosLine = new vscode.Position(position.line, 0);
-//   const endPosLine = new vscode.Position(position.line, position.character);
-//   const rangeLine = new vscode.Range(startPosLine, endPosLine);
-
-//   const lineSplit = document.getText(rangeLine).trim().split(/[ ]+/g);
-//   const lastWord = lineSplit != null ? lineSplit.pop()!.trim() : "";
-
-//   // There are 3 kinds of triggers: Invoke = 0, triggerCharacter = 1, IncompleteItems = 2.
-//   // Invoke always triggers on 24/7 completion (any character typed at start of word) and
-//   // whenever there is a manual call to triggerSuggest. By cancelling out the 24/7 completion
-//   // for Code4Me, we can detect a manual trigger.
-//   if (triggerKind === vscode.CompletionTriggerKind.Invoke) {
-//     // Manual completion on empty line.
-//     if (lastWord.length === 0) return null;
-//     // Likely start of word and triggered on 24/7 completion, do not autocomplete.
-//     else if (lastWord.length === 1 && lastWord.match(/[A-z]+/g)) return undefined;
-//     // Likely start of word and triggered on trigger characters, return trigger character as if trigger completion.
-//     else if (lastWord.slice(lastWord.length - 1).match(/[^A-z]+/g)) return determineTriggerCharacter(document, position, vscode.CompletionTriggerKind.TriggerCharacter);
-//     // Return found trigger word.
-//     else return lastWord;
-//   } else { // TriggerKind = 1, trigger completion
-//     if (allowedTriggerWords.includes(lastWord)) return lastWord;
-//     else if (tripleTriggerCharacter && allowedTriggerCharacters.includes(tripleTriggerCharacter)) return tripleTriggerCharacter;
-//     else if (doubleTriggerCharacter && allowedTriggerCharacters.includes(doubleTriggerCharacter)) return doubleTriggerCharacter;
-//     else if (singleTriggerCharacter && allowedTriggerCharacters.includes(singleTriggerCharacter)) return singleTriggerCharacter;
-//     else return undefined;
-//   }
-// }
-
-// /**
-//  * 
-//  * @param nCharacters the amount of characters taken left and right of the cursor.
-//  * @param position the cursor position.
-//  * @returns an array with index 0 the left text and index 1 the right text. Empty strings if text editor cannot be found.
-//  */
-// function splitTextAtCursor(nCharacters: number, position: vscode.Position): string[] {
-//   const editor = vscode.window.activeTextEditor;
-//   if (!editor) return ['', ''];
-//   const document = editor.document;
-//   const documentLineCount = document.lineCount - 1;
-//   const lastLine = document.lineAt(documentLineCount);
-//   const beginDocumentPosition = new vscode.Position(0, 0);
-//   const leftRange = new vscode.Range(beginDocumentPosition, position);
-
-//   const lastLineCharacterOffset = lastLine.range.end.character;
-//   const lastLineLineOffset = lastLine.lineNumber;
-//   const endDocumentPosition = new vscode.Position(lastLineLineOffset, lastLineCharacterOffset);
-//   const rightRange = new vscode.Range(position, endDocumentPosition);
-
-//   const leftText = editor.document.getText(leftRange);
-//   const rightText = editor.document.getText(rightRange);
-
-//   return [leftText.substring(-nCharacters), rightText.substring(0, nCharacters)];
-// }
-
-// async function callToAPIAndRetrieve(document: vscode.TextDocument, position: vscode.Position, code4MeUuid: string, triggerKind: vscode.CompletionTriggerKind): Promise<any | undefined> {
-//   const textArray = splitTextAtCursor(AVERAGE_TOKEN_LENGHT_IN_CHARACTERS, position);
-//   const triggerPoint = determineTriggerCharacter(document, position, triggerKind);
-//   if (triggerPoint === undefined) return undefined;
-//   const textLeft = textArray[0];
-//   const textRight = textArray[1];
-
-//   const configuration = vscode.workspace.getConfiguration('code4me', undefined);
-  
-//   try {
-//     const url = "https://code4me.me/api/v1/prediction/autocomplete";
-//     const response = await fetch(url, {
-//       method: "POST",
-//       body: JSON.stringify(
-//         {
-//           "leftContext": textLeft,
-//           "rightContext": textRight,
-//           "triggerPoint": triggerPoint,
-//           "language": document.fileName.split('.').pop(),
-//           "ide": "vsc",
-//           "keybind": triggerKind === vscode.CompletionTriggerKind.Invoke,
-//           "pluginVersion": vscode.extensions.getExtension(CODE4ME_EXTENSION_ID)?.packageJSON['version'],
-//           "storeContext": configuration.get('storeContext')
-//         }
-//       ),
-//       headers: {
-//         'Content-Type': 'application/json',
-//         'Authorization': 'Bearer ' + code4MeUuid
-//       }
-//     });
-
-//     if (!response.ok) {
-//       if (response.status == 429) {
-//         showMaxRequestWindow("You have exceeded the limit of 1000 suggestions per hour.");
-//       }
-//       console.error("Response status not OK! Status: ", response.status);
-//       return undefined;
-//     }
-
-//     const contentType = response.headers.get('content-type');
-//     if (!contentType || !contentType.includes('application/json')) {
-//       console.error("Wrong content type!");
-//       return undefined;
-//     }
-
-//     const json = await response.json();
-
-//     if (!Object.prototype.hasOwnProperty.call(json, 'predictions')) {
-//       console.error("Predictions field not found in response!");
-//       return undefined;
-//     }
-//     if (!Object.prototype.hasOwnProperty.call(json, 'verifyToken')) {
-//       console.error("VerifyToken field not found in response!");
-//       return undefined;
-//     }
-//     if (!Object.prototype.hasOwnProperty.call(json, 'survey')) {
-//       console.error("Survey field not found in response!");
-//       return undefined;
-//     }
-//     return json;
-//   } catch (e) {
-//     console.error("Unexpected error: ", e);
-//     showErrorWindow("Unexpected error: " + e);
-//     return undefined;
-//   }
-// }
-
-// // eslint-disable-next-line @typescript-eslint/no-empty-function
-// export function deactivate() { }
-
-
-// NOTE: Class used in user study to provide inline completion items. 
-class CompletionItemProvider implements vscode.CompletionItemProvider {
-
-  constructor(private uuid: string, private config: vscode.WorkspaceConfiguration) {}
-
-  async callCompletionsAPI(document: vscode.TextDocument, position: vscode.Position, triggerKind: vscode.CompletionTriggerKind) {
-    const response: JSON = JSON 
-    // return response.predictions || []
-    // Replace list below with json attribute
-    let predictions: Array<string> = ['pred_new', 'pred_new_2', 'pred_old'] || []
-    // Now we either HAVE a list of completions, or undefined/null maps to empty list
-    predictions = predictions.filter((prediction: string) => prediction !== "");
-
-    return {
-      predictions: predictions || [],
-      verifyToken: 'token' || null,
-      survey: true || false
-    }
-  }
-
-  async provideCompletionItems(
-    document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext
-  ): Promise<vscode.CompletionList | undefined>
-  {
-    const response = await this.callCompletionsAPI(document, position, context.triggerKind);
-    
-    if (response.predictions.length === 0) return undefined 
-
-    const promptSurvey = this.config.get("code4me.promptSurvey");
-    if (response.survey && promptSurvey) doPromptSurvey(this.uuid, this.config);
-
-    const completionToken: string = response.verifyToken;
-    const completionItems :vscode.CompletionItem[] = response.predictions.map((prediction: string) => {
-      return createCompletionItem(prediction, position, document, completionToken, this.uuid)
-    })
-
-    return new vscode.CompletionList(completionItems, false)
-  }
-
-  resolveCompletionItem?(item: vscode.CompletionItem, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CompletionItem> {
-    throw new Error('Method not implemented.');
-  }
-
-}
-
-function createCompletionItem(
-  prediction: string, position: vscode.Position, document: vscode.TextDocument, 
-  completionToken: string, uuid: string
-): vscode.CompletionItem
-{
-  // We filter them out earlier in callCompletionsAPI, to have more type-safe logic 
-  // if (prediction == "") return undefined;
-
-  const item = new vscode.CompletionItem(
-    prediction, 
-    vscode.CompletionItemKind.EnumMember // I chose this because it's less common than 'Property' 
-  )
-  item.insertText = prediction  // No longer necessary as 'detail' now contains the logo
-  item.filterText = prediction  // The culprit of why suggestions were ranked at the bottom
-  item.sortText = '0' // Force sort at the top always (when compared with other identical prefixes)
-  item.detail = '\u276E\uff0f\u276f' // Logo 
-
-  // TODO: in the future, it could be nice to show to users which model generated 
-  // this suggestion. And, maybe even summarise with another LLM
-  item.documentation = 'Code4Me Completion' 
-
-  const positionFromCompletionToEndOfLine = new vscode.Position(position.line, document.lineAt(position.line).range.end.character);
-  const positionPlusOne = new vscode.Position(position.line, position.character + 1);
-  const charactersAfterCursor = document.getText(new vscode.Range(position, positionFromCompletionToEndOfLine));
-  const characterAfterCursor = charactersAfterCursor.charAt(0);
-
-  const lastTwoCharacterOfPrediction = prediction.slice(-2);
-  const lastCharacterOfPrediction = prediction.slice(-1);
-
-  if (lastTwoCharacterOfPrediction === '):' || lastTwoCharacterOfPrediction === ');' || lastTwoCharacterOfPrediction === '),') {
-    item.range = new vscode.Range(position, positionFromCompletionToEndOfLine);
-  } else if (characterAfterCursor === lastCharacterOfPrediction) {
-    item.range = new vscode.Range(position, positionPlusOne);
-  }
-
-  item.command = {
-    command: 'verifyInsertion',
-    title: 'Verify Insertion',
-    arguments: [position, prediction, completionToken, uuid]
-  };
-  return item;
-}
-
-function verifyInsertion(position: vscode.Position, completion: string | null, completionToken: string, apiKey: string) {
-  console.log('verifyInsertion called for completion: ', completion, ' at position: ', position, ' with token: ', completionToken, ' and apiKey: ', apiKey)
-  // if (timer !== null) clearTimeout(timer);
-  const editor = vscode.window.activeTextEditor;
-  const document = editor!.document;
-  const documentName = document.fileName;
-  let lineNumber = position.line;
-  const originalOffset = position.character;
-  let characterOffset = originalOffset;
-
-  const listener = vscode.workspace.onDidChangeTextDocument(event => {
-    if (vscode.window.activeTextEditor == undefined) return;
-    if (vscode.window.activeTextEditor.document.fileName !== documentName) return;
-    for (const changes of event.contentChanges) {
-      const text = changes.text;
-      const startChangedLineNumber = changes.range.start.line;
-      const endChangedLineNumber = changes.range.end.line;
-
-      if (startChangedLineNumber == lineNumber - 1 && endChangedLineNumber == lineNumber && changes.text == '') {
-        lineNumber--;
-        const startLine = document.lineAt(startChangedLineNumber);
-        if (startLine.isEmptyOrWhitespace) characterOffset++;
-        else characterOffset += changes.range.start.character + 1;
-      }
-
-      if (startChangedLineNumber == lineNumber) {
-        if (changes.range.end.character < characterOffset + 1) {
-          if (changes.text === '') {
-            characterOffset -= changes.rangeLength;
-          } if (changes.text.includes('\n')) {
-            characterOffset = originalOffset;
-            lineNumber += (text.match(/\n/g) ?? []).length;
-          } else {
-            characterOffset += changes.text.length;
-          }
-        }
-      } else if (lineNumber == 0 || startChangedLineNumber < lineNumber) {
-        lineNumber += (text.match(/\n/g) ?? []).length;
-      }
-
-      if (changes.range.end.line <= lineNumber) {
-        if (changes.text === '') {
-          lineNumber -= changes.range.end.line - startChangedLineNumber;
-        }
-      }
-    }
-  });
-
-  return setTimeout(async () => {
-    listener.dispose();
-    const lineText = editor?.document.lineAt(lineNumber).text;
-    const response = await fetch("https://code4me.me/api/v1/prediction/verify", {
-      method: 'POST',
-      body: JSON.stringify(
-        {
-          "verifyToken": completionToken,
-          "chosenPrediction": completion,
-          "groundTruth": lineText?.substring(characterOffset).trim()
-        }
-      ),
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + apiKey
-      }
-    });
-
-    if (!response.ok) {
-      console.error("Response status not OK! Status: ", response.status);
-      return undefined;
-    }
-  }, 30000);
-}
-
-function doPromptDataStorageMenu(config: vscode.WorkspaceConfiguration) {
-  vscode.window.showInformationMessage(
-    DATA_STORAGE_WINDOW_REQUEST_TEXT,
-    DATA_STORAGE_OPT_IN,
-    DATA_STORAGE_REMIND_ME,
-    DATA_STORAGE_OPT_OUT,
-    DATA_STORAGE_READ_MORE
-  ).then(selection => {
-    const url = `https://code4me.me/`;
-
-    switch (selection) {
-      case DATA_STORAGE_OPT_IN:
-        config.update('storeContext', true, true);
-        config.update('promptDataStorage', false, true);
-        break;
-      case DATA_STORAGE_OPT_OUT:
-        config.update('promptDataStorage', false, true);
-        break;
-      case DATA_STORAGE_READ_MORE:
-        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
-        vscode.commands.executeCommand("workbench.action.openSettings", "code4me.storeContext");
-        config.update('promptDataStorage', false, true);
-        break;
-      default:
-        break;
-    }
-  });
-}
-
-function doPromptSurvey(uuid: string, config: vscode.WorkspaceConfiguration) {
-  vscode.window.showInformationMessage(
-    SURVEY_WINDOW_REQUEST_TEXT,
-    SURVEY_WINDOW_SURVEY,
-    INFORMATION_WINDOW_CLOSE,
-    INFORMATION_WINDOW_DONT_SHOW_AGAIN
-  ).then(selection => {
-    if (selection === SURVEY_WINDOW_SURVEY) {
-      const url = `https://code4me.me/api/v1/survey?user_id=${uuid}`;
-      vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
-    }
-    if (selection === INFORMATION_WINDOW_DONT_SHOW_AGAIN) {
-      config.update('promptSurvey', false, true);
-    }
-  });
-}


### PR DESCRIPTION
This request updates the VSC Plugin and adds new respective APIs for a user study on developer interactions with code completions. The JetBrains plugin and its APIs are unaffected. User study data is stored under a new subdirectory `data_aral`.

The general motivation behind the modifications proposed in this PR is to more closely resemble the SOTA code-completion tools that continuously generate suggestions; while also preventing the target LLMs from generating suggestions unnecessarily.

**Fixes**
- [x] Plugin build configuration for hot-reloading during development (seemed outdated). 
- [x] Extension objects are now disposed of when the plugin is disabled. 
- [x] Fixes rankings in VSCode to show `Code4Me` completions at the top. 
- [x] Bugfix CodeGPT generation: prefix was trimmed twice, resulting in errors if the cursor is on an empty newline. This was likely a source of memory leaks as the resulting tensors are created on the GPU and not disposed of. 
- [x] Debounces automatic invocations to when the user has stopped typing (and labels them as `'auto'` instead of manual). 
- [x] Stored JSON fields to follow Pythonic `snake_case` convention, as they are going to be used in data analysis anyway. 
- [x] `language` field determined using `vsc` API instead of file extension. 

**Adds**
- [x] New `idle` invocation type, after the user has not interacted for 2s. Completions are not shown if none are received (as opposed to IntelliSense's default `No Completions` indicator).
- [x] Tracks manual invocations.
- [x] If a completion is generated while the user is still typing, we try to match the last few characters with the completion so they are not duplicated. 
- [x] Stores time a suggestion is displayed, and accepted. 
- [x] Explicitly receives and sends the models, so the model that generated an accepted completion can be retrieved deterministically even if the completion is the same as another model. Also shows the model to the user when they press `⌃Space` again. 
- [x] The context for completions is always stored in the user study. ReadMe is updated to reflect that developers who use the tool, agree to these terms. 

- [x] Server-side filter for rejecting completions likely to be ignored or useless to the user. The user is assigned one of four filters for a session (where two completions are no more than 30 minutes apart). The filters are:
  1. A simple logistic-regression model leveraging telemetry data. 
  2. A `CodeBERTa` model fine-tuned on the code context surrounding the cursor. 
  3. Two `JonBERTa` models (custom architecture) leveraging both telemetry and code context. 
- [x] Option for testing deployment locally. Run `flask app` with env variables `CODE4ME_TEST=true` and `CODEGPT_CHECKPOINT_PATH` set to a model from HF (e.g. `'microsoft/CodeGPT-small-py'`). 

**Todos**
- [ ] Server-side
  - [ ] Disabled survey check at `code4me-server/api.py > autocomplete` because it requires globbing a directory with >1M files on every completion request. Consider sorting completions under user-hash subdirectories as a more scalable approach. 
  - [ ] Store model confidence per a given completion. 
  - [ ] Generate multiple predictions per model, ranking them client side based on similarity to the current context. 
  - [ ] Fix other memory leaks. 
  - [ ] Avoid saving empty JSON files. 
  - [ ] Add additional language support for filters.

- [ ] Client-side (`vsc`)
  - [ ] Found bug in `vsc` ground-truth-tracking. MRE: Call completion on line 3, then delete line 3; results in tracking `lineNumber=1`. 
  - [ ] Collect ground truth at additional intervals (1, 2, 5, 10, 30 minutes)
  - [ ] Caching to prevent re-generating completions when the user deletes something. 
  - [ ] Support for multi-line ghost-text-style completions. 