### PR TITLE
Action for user-study branch to be published to VSC Marketplace

### DIFF
--- a/.github/workflows/release-vsc-aral.yml
+++ b/.github/workflows/release-vsc-aral.yml
@@ -1,0 +1,52 @@
+# Created a new workflow because it seems notoriously difficult to include 
+# two branches in one action with differing conditions *and* without side effects. 
+
+# As I assume some of the changes in the user study PR to be temporary, 
+# I feel like having this temporary action is the best option. 
+
+name: Release VSC Plugin (User Study) 
+on:
+  push:
+    branches: [aral_user_study]
+    paths:
+      - code4me-vsc-plugin/**
+    tags: 
+     - v1.*
+
+env:
+  WORKING_DIRECTORY: code4me-vsc-plugin
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Commit Message
+        id: check-commit
+        run: |
+          if [[ "${{ github.event.head_commit.message }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\-[a-zA-Z]+)?$ ]]; then
+              echo ::set-output name=isSemver::true
+          fi
+      - uses: actions/checkout@v3
+        if: steps.check-commit.outputs.isSemver == 'true'
+      - uses: actions/setup-node@v3
+        if: steps.check-commit.outputs.isSemver == 'true'
+        with:
+          node-version: 16
+          cache: 'npm'
+          cache-dependency-path: code4me-vsc-plugin/package-lock.json
+
+      - name: Install the dependencies
+        if: steps.check-commit.outputs.isSemver == 'true'
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: npm i
+
+      - name: Install vsce
+        if: steps.check-commit.outputs.isSemver == 'true'
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: npm i -g vsce
+
+      - name: Publish
+        if: steps.check-commit.outputs.isSemver == 'true'
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: vsce publish -p ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
This is an alternative to directly merging PR #38  into main. It allows me to publish the `vsc` plugin from a tagged commit on the `aral_user_study` branch. 