### PR TITLE
Server Fixes

### DIFF
--- a/code4me-server/src/api.py
+++ b/code4me-server/src/api.py
@@ -1,5 +1,5 @@
 from __future__ import annotations 
-import os, time, random, json, uuid, glob, torch, traceback
+import os, time, random, json, uuid, torch, traceback
 
 from enum import Enum
 from typing import List, Tuple
@@ -182,7 +182,9 @@ def autocomplete():
 
     verify_token = uuid.uuid4().hex
 
-    with open(f"data/{user_token}-{verify_token}.json", "w+") as f:
+    user_dir = os.path.join("data", user_token)
+    os.makedirs(user_dir, exist_ok=True)
+    with open(os.path.join(user_dir, f"{verify_token}.json"), "w+") as f:
         f.write(json.dumps({
             "completionTimestamp": datetime.now().isoformat(),
             "triggerPoint": values["triggerPoint"],
@@ -199,9 +201,8 @@ def autocomplete():
             "rightContext": right_context if store_context else None
         }))
 
-    # # # TODO: disabled surveys temporarily, as we are currently looking through >1M files on every request. 
-    # n_suggestions = len(glob.glob(f"data/{user_token}*.json"))
-    # survey = n_suggestions >= 100 and n_suggestions % 50 == 0
+    n_suggestions = len(os.listdir(user_dir))
+    survey = n_suggestions >= 100 and n_suggestions % 50 == 0
     survey = False
 
     return response({
@@ -230,7 +231,7 @@ def verify():
         return res
 
     verify_token = values["verifyToken"]
-    file_path = f"data/{user_token}-{verify_token}.json"
+    file_path = os.path.join("data", user_token, f"{verify_token}.json")
     if not os.path.exists(file_path):
         return response({
             "error": "Invalid verify token"

--- a/code4me-server/src/query_filter.py
+++ b/code4me-server/src/query_filter.py
@@ -186,7 +186,7 @@ class Filter(enum.Enum):
     JOINT_H = 'joint_h'
     JOINT_A = 'joint_a'
 
-no_filter = lambda request_json: True 
+no_filter = lambda request_json: False 
 logres = Logres(coef, intercept)
 set_all_seeds() # just in case 
 context_filter = MyPipeline( device=DEVICE, task='text-classification',

--- a/code4me-vsc-plugin/src/extension.ts
+++ b/code4me-vsc-plugin/src/extension.ts
@@ -362,12 +362,12 @@ class CompletionItemProvider implements vscode.CompletionItemProvider {
     item.detail = '\u276E\uff0f\u276f' // Added the Logo here instead 
     item.documentation = 'Completion from ' + model
 
+    item.shownTimes = [new Date().toISOString()];
     item.command = {
       command: 'verifyInsertion',
       title: 'Verify Insertion',
       arguments: [prediction, position, document, verifyToken, this.uuid, item.shownTimes, () => {this.setIdleTrigger()}]
     };
-    item.shownTimes = [new Date().toISOString()];
 
     // This is useful if you want to see what's exactly going on with the range and prefix modifications
     // I use • to denote the cursor position


### PR DESCRIPTION
Fixes/updates the following server-side components:

- [x] Store `v1` user requests under `data/user_uuid/json_uuid.json`, to avoid counting all invocations on every request. However, this brings two issues:
  - [ ] Need to convert previous data from `user_uuid-json_uuid.json` to `user_uuid/json_uuid.json`; but this can be done with a simple replacement command on the server. 
  - [ ] Mark's data analysis scripts may need to be updated to follow this convention. (the first thing mine do is sort the data into this `user/json` structure to make processing locally manageable). 

- [x] Fix User Study passthrough filter; I forgot to save before amending my last commit on the `aral_user_study` branch. 
- [ ] 