### PR TITLE
User study bugfix

### DIFF
--- a/code4me-server/src/api.py
+++ b/code4me-server/src/api.py
@@ -1,5 +1,5 @@
 from __future__ import annotations 
-import os, time, random, json, uuid, glob, torch, traceback
+import os, time, random, json, uuid, torch, traceback
 
 from enum import Enum
 from typing import List, Tuple
@@ -182,7 +182,9 @@ def autocomplete():
 
     verify_token = uuid.uuid4().hex
 
-    with open(f"data/{user_token}-{verify_token}.json", "w+") as f:
+    user_dir = os.path.join("data", user_token)
+    os.makedirs(user_dir, exist_ok=True)
+    with open(os.path.join(user_dir, f"{verify_token}.json"), "w+") as f:
         f.write(json.dumps({
             "completionTimestamp": datetime.now().isoformat(),
             "triggerPoint": values["triggerPoint"],
@@ -199,9 +201,8 @@ def autocomplete():
             "rightContext": right_context if store_context else None
         }))
 
-    # # # TODO: disabled surveys temporarily, as we are currently looking through >1M files on every request. 
-    # n_suggestions = len(glob.glob(f"data/{user_token}*.json"))
-    # survey = n_suggestions >= 100 and n_suggestions % 50 == 0
+    n_suggestions = len(os.listdir(user_dir))
+    survey = n_suggestions >= 100 and n_suggestions % 50 == 0
     survey = False
 
     return response({
@@ -230,7 +231,7 @@ def verify():
         return res
 
     verify_token = values["verifyToken"]
-    file_path = f"data/{user_token}-{verify_token}.json"
+    file_path = os.path.join("data", user_token, f"{verify_token}.json")
     if not os.path.exists(file_path):
         return response({
             "error": "Invalid verify token"

--- a/code4me-server/src/api.py
+++ b/code4me-server/src/api.py
@@ -68,7 +68,7 @@ def autocomplete_v2():
         log_context = f'{request_json["prefix"][-10:]}•{request_json["suffix"][:5]}'
         current_app.logger.warning(f'{log_filter} {log_context} \t{filter_type} {[v[:10] for v in predictions.values()]}')
 
-        verify_token = uuid.uuid4().hex if not should_filter else ''
+        verify_token = uuid.uuid4().hex 
         prompt_survey = should_prompt_survey(user_uuid) if not should_filter else False
 
         store_completion_request(user_uuid, verify_token, {

--- a/code4me-server/src/query_filter.py
+++ b/code4me-server/src/query_filter.py
@@ -186,7 +186,7 @@ class Filter(enum.Enum):
     JOINT_H = 'joint_h'
     JOINT_A = 'joint_a'
 
-no_filter = lambda request_json: True 
+no_filter = lambda request_json: False 
 logres = Logres(coef, intercept)
 set_all_seeds() # just in case 
 context_filter = MyPipeline( device=DEVICE, task='text-classification',

--- a/code4me-vsc-plugin/package.json
+++ b/code4me-vsc-plugin/package.json
@@ -4,7 +4,7 @@
 	"description": "Language model code completion.",
 	"author": "Code4Me",
 	"license": "Apache-2.0",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"categories": [
 		"Machine Learning",
 		"Programming Languages",

--- a/code4me-vsc-plugin/src/extension.ts
+++ b/code4me-vsc-plugin/src/extension.ts
@@ -62,7 +62,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   start(context).then(disposable => {
     context.subscriptions.push(disposable);
-    console.log('Code4me Activated!')
+    console.log(`Code4Me Activated! v${CODE4ME_VERSION}`)
   })
 }
 
@@ -362,12 +362,12 @@ class CompletionItemProvider implements vscode.CompletionItemProvider {
     item.detail = '\u276E\uff0f\u276f' // Added the Logo here instead 
     item.documentation = 'Completion from ' + model
 
+    item.shownTimes = [new Date().toISOString()];
     item.command = {
       command: 'verifyInsertion',
       title: 'Verify Insertion',
       arguments: [prediction, position, document, verifyToken, this.uuid, item.shownTimes, () => {this.setIdleTrigger()}]
     };
-    item.shownTimes = [new Date().toISOString()];
 
     // This is useful if you want to see what's exactly going on with the range and prefix modifications
     // I use • to denote the cursor position


### PR DESCRIPTION
Fixes/updates the following server-side components:
- [x] Upgrade CUDA drivers `11.4 -> 12.2` and NVIDIA to [gpgpu](https://www.gigabyte.com/Glossary/gpgpu) (not actually part of this PR code-wise; but was necessary)
- [x] use [`vLLM`](https://github.com/vllm-project/vllm) for batching requests and Paged Attention. Engines at `0.9` fractional GPU utilisation; `20GB` swap space. 
- [x] Add [`StarCoder2-3b`](https://huggingface.co/bigcode/starcoder2-3b) as a backend model, replacing `CodeGPT` and `UniXCoder`.
  - [x] Load in `float16`.
  - [ ] Ensure infilling-mode works correctly (see [hf thread](https://huggingface.co/bigcode/starcoder2-15b/discussions/6))
- [ ] Why do we store ground truths only for accepted completions? 

- [x] Store `v1` user requests under `data/user_uuid/json_uuid.json`, to avoid counting all invocations on every request. However, this brings two issues:
  - [ ] Need to convert previous data from `user_uuid-json_uuid.json` to `user_uuid/json_uuid.json`; but this can be done with a simple replacement command on the server. 
  - [ ] Mark's data analysis scripts may need to be updated to follow this convention. (the first thing mine do is sort the data into this `user/json` structure to make processing locally manageable). 

- [x] Fix User Study passthrough filter; I forgot to save before amending my last commit on the `aral_user_study` branch. 

Client side (`vsc`): 
- [x] Fix `shown_times` is used before declared.